### PR TITLE
VPN connectivity dashboard pipeline fix 

### DIFF
--- a/DataQualityDashboard/Dockerfile
+++ b/DataQualityDashboard/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY DataQualityDashboard/drivers/ drivers/
-COPY DataQualityDashboard/scripts/ .
+COPY drivers/ drivers/
+COPY scripts/ .
 
 RUN [ "Rscript", "dependencies.r"]
 

--- a/DataQualityDashboard/README.md
+++ b/DataQualityDashboard/README.md
@@ -44,10 +44,23 @@ SETTINGS=;Database=omoptest;Encrypt=False;TrustServerCertificate=False;
 
 ## Running the Pipeline
 
-### Powershell Execution
+#### Image Build (Offline/Non-VPN)
 
-Run the pipeline using `run.ps1` with an output path argument, this will be where you want the containers output files to be saved:
+Navigate to the project directory:
+```powershell
+cd DataQualityDashboard
+```
 
+Build the Docker image:
+```powershell
+powershell ./build.ps1
+```
+**Note:** Ensure you are NOT connected to the VPN when building the image.
+
+#### Pipeline Execution
+You may now connect to the VPN, depending on wether your data is stored on a secure server which requires the VPN, if it's local no VPN is required.
+
+Run the pipeline script:
 ```powershell
 powershell ./run.ps1 -outpath "C:\path\to\output\directory"
 ```

--- a/DataQualityDashboard/build.ps1
+++ b/DataQualityDashboard/build.ps1
@@ -1,0 +1,1 @@
+docker build -t dqdash -f Dockerfile .

--- a/DataQualityDashboard/run.ps1
+++ b/DataQualityDashboard/run.ps1
@@ -2,9 +2,6 @@ param (
     [string]$outpath
 )
 
-# Build the Docker image
-docker build -t dqdash -f Dockerfile .
-
 # Generate container name
 $containerName = "temp-container"
 

--- a/DataQualityDashboard/scripts/main.r
+++ b/DataQualityDashboard/scripts/main.r
@@ -31,7 +31,7 @@ outputFile <- "results.json"
 verboseMode <- TRUE
 
 # Write results to SQL table and/or CSV file
-writeToTable <- TRUE
+writeToTable <- FALSE
 writeToCsv <- FALSE
 csvFile <- ""
 


### PR DESCRIPTION
Split the pipeline into `build` and `run` scripts.

The `build` script can only be run off the VPN, to download and install dependencies.

The `run` script can be run on or off the VPN as it uses the cached docker image in the container.

Docs have been updated accordingly