### PR TITLE
Update HospitalProviderSpellNumber Data Type

### DIFF
--- a/Database/Migrations/sql/VersionedMigrations/V61__Update_spell_type.sql
+++ b/Database/Migrations/sql/VersionedMigrations/V61__Update_spell_type.sql
@@ -1,0 +1,92 @@
+-- Observation
+
+drop index [IDX_cdm_observation_person_id_observation_date_observation_concept_id_RecordConnectionIdentifier_HospitalProviderSpellNumber] on cdm.observation;
+
+go
+
+EXEC sp_rename 'cdm.observation.HospitalProviderSpellNumber', 'HospitalProviderSpellNumber1', 'COLUMN';
+
+alter table cdm.observation
+	add HospitalProviderSpellNumber varchar(100) null;
+
+go
+
+update cdm.observation
+set HospitalProviderSpellNumber = HospitalProviderSpellNumber1;
+
+alter table cdm.observation
+	drop column HospitalProviderSpellNumber1;
+
+go
+
+/****** Object:  Index [IDX_cdm_observation_person_id_observation_date_observation_concept_id_RecordConnectionIdentifier_HospitalProviderSpellNumber]    Script Date: 20/01/2025 14:20:33 ******/
+CREATE NONCLUSTERED INDEX [IDX_cdm_observation_person_id_observation_date_observation_concept_id_RecordConnectionIdentifier_HospitalProviderSpellNumber] ON [cdm].[observation]
+(
+	[person_id] ASC,
+	[observation_date] ASC,
+	[observation_concept_id] ASC,
+	[RecordConnectionIdentifier] ASC,
+	[HospitalProviderSpellNumber] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+GO
+
+
+-- Visit detail
+
+
+drop index [IDX_cdm_visit_details_HospitalProviderSpellNumber_person_id] ON [cdm].[visit_detail];
+
+go
+
+EXEC sp_rename 'cdm.visit_detail.HospitalProviderSpellNumber', 'HospitalProviderSpellNumber1', 'COLUMN';
+
+go
+
+alter table cdm.visit_detail
+	add HospitalProviderSpellNumber varchar(100) null;
+
+go
+
+update cdm.visit_detail
+set HospitalProviderSpellNumber = HospitalProviderSpellNumber1;
+
+go
+
+alter table cdm.visit_detail
+	drop column HospitalProviderSpellNumber1;
+
+
+CREATE NONCLUSTERED INDEX [IDX_cdm_visit_details_HospitalProviderSpellNumber_person_id] ON [cdm].[visit_detail]
+(
+	[person_id] ASC,
+	[HospitalProviderSpellNumber] ASC
+)
+INCLUDE([visit_occurrence_id])
+
+
+-- Visit occuurrence
+
+DROP INDEX [FI_cdm_visit_occurrence_HospitalProviderSpellNumber] ON [cdm].[visit_occurrence]
+
+GO
+
+EXEC sp_rename 'cdm.visit_occurrence.HospitalProviderSpellNumber', 'HospitalProviderSpellNumber1', 'COLUMN';
+
+go
+
+alter table cdm.visit_occurrence
+	add HospitalProviderSpellNumber varchar(100) null;
+
+go
+
+update cdm.visit_occurrence
+set HospitalProviderSpellNumber = HospitalProviderSpellNumber1;
+
+alter table cdm.visit_occurrence
+	drop column HospitalProviderSpellNumber1;
+
+CREATE UNIQUE NONCLUSTERED INDEX [FI_cdm_visit_occurrence_HospitalProviderSpellNumber] ON [cdm].[visit_occurrence]
+(
+	[HospitalProviderSpellNumber] ASC
+)
+WHERE ([HospitalProviderSpellNumber] IS NOT NULL)

--- a/OmopTransformer/CDS/Observation/AnaestheticDuringLabourDelivery/CdsAnaestheticDuringLabourDelivery.cs
+++ b/OmopTransformer/CDS/Observation/AnaestheticDuringLabourDelivery/CdsAnaestheticDuringLabourDelivery.cs
@@ -17,8 +17,8 @@ internal class CdsAnaestheticDuringLabourDelivery : OmopObservation<CdsAnaesthet
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4163264, "Type of anesthetic")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/AnaestheticGivenPostLabourDelivery/CdsAnaestheticGivenPostLabourDelivery.cs
+++ b/OmopTransformer/CDS/Observation/AnaestheticGivenPostLabourDelivery/CdsAnaestheticGivenPostLabourDelivery.cs
@@ -17,8 +17,8 @@ internal class CdsAnaestheticGivenPostLabourDelivery : OmopObservation<CdsAnaest
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4163264, "Type of anesthetic")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/BirthWeight/CdsBirthWeight.cs
+++ b/OmopTransformer/CDS/Observation/BirthWeight/CdsBirthWeight.cs
@@ -17,8 +17,8 @@ internal class CdsBirthWeight : OmopObservation<CdsBirthWeightRecord>
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(3662222, "Weight of neonate at birth")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/CarerSupportIndicator/CdsCarerSupportIndicator.cs
+++ b/OmopTransformer/CDS/Observation/CarerSupportIndicator/CdsCarerSupportIndicator.cs
@@ -17,8 +17,8 @@ internal class CdsCarerSupportIndicator : OmopObservation<CdsCarerSupportIndicat
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4224770, "Social support status")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/GestationLengthLabourOnset/CdsGestationLengthLabourOnset.cs
+++ b/OmopTransformer/CDS/Observation/GestationLengthLabourOnset/CdsGestationLengthLabourOnset.cs
@@ -17,8 +17,8 @@ internal class CdsGestationLengthLabourOnset : OmopObservation<CdsGestationLengt
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(40493181, "Length of gestation at time of procedure")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/NumberOfBabies/CdsNumberOfBabies.cs
+++ b/OmopTransformer/CDS/Observation/NumberOfBabies/CdsNumberOfBabies.cs
@@ -17,8 +17,8 @@ internal class CdsNumberOfBabies : OmopObservation<CdsNumberOfBabiesRecord>
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4209211, "Number of births at term")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/PersonWeight/CdsPersonWeight.cs
+++ b/OmopTransformer/CDS/Observation/PersonWeight/CdsPersonWeight.cs
@@ -17,8 +17,8 @@ internal class CdsPersonWeight : OmopObservation<CdsPersonWeightRecord>
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(42536495, "Current body weight")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/SourceOfReferralForOutpatients/CdsSourceOfReferralForOutpatients.cs
+++ b/OmopTransformer/CDS/Observation/SourceOfReferralForOutpatients/CdsSourceOfReferralForOutpatients.cs
@@ -17,8 +17,8 @@ internal class CdsSourceOfReferralForOutpatients : OmopObservation<CdsSourceOfRe
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/Observation/TotalPreviousPregnancies/CdsTotalPreviousPregnancies.cs
+++ b/OmopTransformer/CDS/Observation/TotalPreviousPregnancies/CdsTotalPreviousPregnancies.cs
@@ -17,8 +17,8 @@ internal class CdsTotalPreviousPregnancies : OmopObservation<CdsTotalPreviousPre
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4078008, "Number of previous pregnancies")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/CDS/VisitDetails/CdsVisitDetail.cs
+++ b/OmopTransformer/CDS/VisitDetails/CdsVisitDetail.cs
@@ -19,7 +19,7 @@ internal class CdsVisitDetail : OmopVisitDetail<CdsVisitDetailsRecord>
     public override string? RecordConnectionIdentifier { get; set; }
 
     [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.VisitStartDate))]
     public override DateTime? visit_detail_start_date { get; set; }

--- a/OmopTransformer/CDS/VisitDetails/CdsVisitDetailsRecord.cs
+++ b/OmopTransformer/CDS/VisitDetails/CdsVisitDetailsRecord.cs
@@ -9,7 +9,7 @@ internal class CdsVisitDetailsRecord
 {
     public string? NHSNumber { get; set; }
     public string? RecordConnectionIdentifier { get; set; }
-    public int? HospitalProviderSpellNumber { get; set; }
+    public string? HospitalProviderSpellNumber { get; set; }
     public string? VisitStartDate { get; set; }
     public string? VisitStartTime { get; set; }
     public string? VisitEndDate { get; set; }

--- a/OmopTransformer/CDS/VisitOccurrenceWithSpell/CdsVisitOccurrenceWithSpell.cs
+++ b/OmopTransformer/CDS/VisitOccurrenceWithSpell/CdsVisitOccurrenceWithSpell.cs
@@ -15,8 +15,8 @@ internal class CdsVisitOccurrenceWithSpell : OmopVisitOccurrence<CdsVisitOccurre
     [CopyValue(nameof(Source.NHSNumber))]
     public override string? NhsNumber { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.EpisodeStartDate))]
     public override DateTime? visit_start_date { get; set; }

--- a/OmopTransformer/Omop/Observation/OmopObservation.cs
+++ b/OmopTransformer/Omop/Observation/OmopObservation.cs
@@ -4,7 +4,7 @@ internal abstract class OmopObservation<T> : IOmopRecord<T>
 {
     public virtual string? nhs_number { get; set; }
     public virtual string? RecordConnectionIdentifier { get; set; }
-    public virtual int? HospitalProviderSpellNumber { get; set; }
+    public virtual string? HospitalProviderSpellNumber { get; set; }
     public virtual int? observation_concept_id { get; set; }
     public virtual DateTime? observation_date { get; set; }
     public virtual DateTime? observation_datetime { get; set; }

--- a/OmopTransformer/Omop/VisitDetail/OmopVisitDetail.cs
+++ b/OmopTransformer/Omop/VisitDetail/OmopVisitDetail.cs
@@ -3,7 +3,7 @@
 internal abstract class OmopVisitDetail<T> : IOmopRecord<T>
 {
     public virtual string? nhs_number { get; set; }
-    public virtual int? HospitalProviderSpellNumber { get; set; }
+    public virtual string? HospitalProviderSpellNumber { get; set; }
     public virtual string? RecordConnectionIdentifier { get; set; }
     public virtual int? visit_detail_concept_id { get; set; }
     public virtual DateTime? visit_detail_start_date { get; set; }

--- a/OmopTransformer/Omop/VisitOccurrence/OmopVisitOccurrence.cs
+++ b/OmopTransformer/Omop/VisitOccurrence/OmopVisitOccurrence.cs
@@ -18,7 +18,7 @@ internal abstract class OmopVisitOccurrence<T> : IOmopRecord<T>
     public virtual int? discharged_to_concept_id { get; set; }
     public virtual string? discharged_to_source_value { get; set; }
     public virtual int? preceding_visit_occurrence_id { get; set; }
-    public virtual int? HospitalProviderSpellNumber { get; set; }
+    public virtual string? HospitalProviderSpellNumber { get; set; }
     public virtual string? RecordConnectionIdentifier { get; set; }
     public string OmopTargetTypeDescription => "VisitOccurrence";
     public T? Source { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/AnaestheticDuringLabourDelivery/SusAPCAnaestheticDuringLabourDelivery.cs
+++ b/OmopTransformer/SUS/APC/Observation/AnaestheticDuringLabourDelivery/SusAPCAnaestheticDuringLabourDelivery.cs
@@ -17,8 +17,8 @@ internal class SusAPCAnaestheticDuringLabourDelivery : OmopObservation<SusAPCAna
     [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4163264, "Type of anesthetic")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/AnaestheticGivenPostLabourDelivery/SusAPCAnaestheticGivenPostLabourDelivery.cs
+++ b/OmopTransformer/SUS/APC/Observation/AnaestheticGivenPostLabourDelivery/SusAPCAnaestheticGivenPostLabourDelivery.cs
@@ -17,8 +17,8 @@ internal class SusAPCAnaestheticGivenPostLabourDelivery : OmopObservation<SusAPC
     [CopyValue(nameof(Source.RecordConnectionIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4163264, "Type of anesthetic")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/BirthWeight/SusAPCBirthWeight.cs
+++ b/OmopTransformer/SUS/APC/Observation/BirthWeight/SusAPCBirthWeight.cs
@@ -17,8 +17,8 @@ internal class SusAPCBirthWeight : OmopObservation<SusAPCBirthWeightRecord>
     [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(3662222, "Weight of neonate at birth")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/CarerSupportIndicator/SusAPCCarerSupportIndicator.cs
+++ b/OmopTransformer/SUS/APC/Observation/CarerSupportIndicator/SusAPCCarerSupportIndicator.cs
@@ -17,8 +17,8 @@ internal class SusAPCCarerSupportIndicator : OmopObservation<SusAPCCarerSupportI
     [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4224770, "Social support status")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/GestationLengthLabourOnset/SusAPCGestationLengthLabourOnset.cs
+++ b/OmopTransformer/SUS/APC/Observation/GestationLengthLabourOnset/SusAPCGestationLengthLabourOnset.cs
@@ -17,8 +17,8 @@ internal class SusAPCGestationLengthLabourOnset : OmopObservation<SusAPCGestatio
     [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(40493181, "Length of gestation at time of procedure")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/NumberOfBabies/SusAPCNumberOfBabies.cs
+++ b/OmopTransformer/SUS/APC/Observation/NumberOfBabies/SusAPCNumberOfBabies.cs
@@ -17,8 +17,8 @@ internal class SusAPCNumberOfBabies : OmopObservation<SusAPCNumberOfBabiesRecord
     [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4209211, "Number of births at term")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/TotalPreviousPregnancies/SusAPCTotalPreviousPregnancies.cs
+++ b/OmopTransformer/SUS/APC/Observation/TotalPreviousPregnancies/SusAPCTotalPreviousPregnancies.cs
@@ -17,8 +17,8 @@ internal class SusAPCTotalPreviousPregnancies : OmopObservation<SusAPCTotalPrevi
     [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
     public override string? RecordConnectionIdentifier { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4078008, "Number of previous pregnancies")]
     public override int? observation_concept_id { get; set; }

--- a/OmopTransformer/SUS/APC/VisitDetails/SusAPCVisitDetail.cs
+++ b/OmopTransformer/SUS/APC/VisitDetails/SusAPCVisitDetail.cs
@@ -19,7 +19,7 @@ internal class SusAPCVisitDetail : OmopVisitDetail<SusAPCVisitDetailsRecord>
     public override string? RecordConnectionIdentifier { get; set; }
 
     [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.VisitStartDate))]
     public override DateTime? visit_detail_start_date { get; set; }

--- a/OmopTransformer/SUS/APC/VisitDetails/SusAPCVisitDetailsRecord.cs
+++ b/OmopTransformer/SUS/APC/VisitDetails/SusAPCVisitDetailsRecord.cs
@@ -9,7 +9,7 @@ internal class SusAPCVisitDetailsRecord
 {
     public string? NHSNumber { get; set; }
     public string? GeneratedRecordIdentifier { get; set; }
-    public int? HospitalProviderSpellNumber { get; set; }
+    public string? HospitalProviderSpellNumber { get; set; }
     public string? VisitStartDate { get; set; }
     public string? VisitStartTime { get; set; }
     public string? VisitEndDate { get; set; }

--- a/OmopTransformer/SUS/APC/VisitOccurrenceWithSpell/SusAPCVisitOccurrenceWithSpell.cs
+++ b/OmopTransformer/SUS/APC/VisitOccurrenceWithSpell/SusAPCVisitOccurrenceWithSpell.cs
@@ -15,8 +15,8 @@ internal class SusAPCVisitOccurrenceWithSpell : OmopVisitOccurrence<SusAPCVisitO
     [CopyValue(nameof(Source.NHSNumber))]
     public override string? NhsNumber { get; set; }
 
-    [Transform(typeof(NumberParser), nameof(Source.HospitalProviderSpellNumber))]
-    public override int? HospitalProviderSpellNumber { get; set; }
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.EpisodeStartDate))]
     public override DateTime? visit_start_date { get; set; }


### PR DESCRIPTION
As `SUSgeneratedspellID` (`HospitalProviderSpellNumber`) in OP is too large to be an int, convert all `HospitalProviderSpellNumber` references to use string data type.

Also align with SUS+ SEM spec:

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/TomHolt/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/TomHolt/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link=blue vlink=purple>

Hospital   Provider Spell Number | A unique   identifier for a hospital spell within a healthcare provider. It should be   the same for all the episodes     within the same hospital spell. | String(20) (If   pseudonymised: String(32))
-- | -- | --

</body>

</html>

---

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/TomHolt/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/TomHolt/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link=blue vlink=purple>

SUS   generated spell ID | Unique Spell ID   following SUS Spell creation          System generated value spell id, this id is consistent across all records   belonging to the same spell. | String(38) (If   pseudonymised: String(32))
-- | -- | --

</body>

</html>
