### PR TITLE
AE Observations & SUS improvements

### DIFF
--- a/OmopTransformer/OmopTransformer.csproj
+++ b/OmopTransformer/OmopTransformer.csproj
@@ -402,6 +402,15 @@
     <None Update="SUS\AE\VisitOccurrenceWithSpell\SusAEVisitOccurrenceWithSpell.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="SUS\AE\Observation\SourceOfReferralForOutpatients\SusAESourceOfReferralForOutpatients.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="SUS\AE\Observation\DiabeticPatient\SusAEDiabeticPatient.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="SUS\AE\Observation\AsthmaticPatient\SusAEAsthmaticPatient.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		<ItemGroup>

--- a/OmopTransformer/SUS/AE/Death/SusAEDeath.xml
+++ b/OmopTransformer/SUS/AE/Death/SusAEDeath.xml
@@ -1,14 +1,15 @@
 ﻿<Query>
     <Sql>
-	select
-		NHSNumber as nhs_number,
-		coalesce(max(ReferralToTreatmentPeriodEndDate), max(CDSActivityDate)) as death_date
-	from [omop_staging].[sus_AE]
-	where ((ReferralToTreatmentPeriodStatus = 36) --PATIENT died before treatment
-		or (AEPatientGroup = 70)) -- PATIENT brought in dead
-		and (CDSActivityDate is not null or ReferralToTreatmentPeriodEndDate is not null)
-		and NHSNumber is not null
-	group by NHSNumber
+select
+	NHSNumber as nhs_number,
+	coalesce(max(ReferralToTreatmentPeriodEndDate), max(CDSActivityDate)) as death_date
+from [omop_staging].[sus_AE]
+where ((ReferralToTreatmentPeriodStatus = 36) --PATIENT died before treatment
+	or (AEPatientGroup = 70)
+	or (AEAttendanceDisposal = 10)) -- PATIENT brought in dead
+	and (CDSActivityDate is not null or ReferralToTreatmentPeriodEndDate is not null)
+	and NHSNumber is not null
+group by NHSNumber
 	</Sql>
 
 	<Explanations>

--- a/OmopTransformer/SUS/AE/Death/SusAEDeath.xml
+++ b/OmopTransformer/SUS/AE/Death/SusAEDeath.xml
@@ -5,8 +5,8 @@ select
 	coalesce(max(ReferralToTreatmentPeriodEndDate), max(CDSActivityDate)) as death_date
 from [omop_staging].[sus_AE]
 where ((ReferralToTreatmentPeriodStatus = 36) --PATIENT died before treatment
-	or (AEPatientGroup = 70)
-	or (AEAttendanceDisposal = 10)) -- PATIENT brought in dead
+	or (AEPatientGroup = 70) -- PATIENT brought in dead
+	or (AEAttendanceDisposal = 10))  --PATIENT died in AE
 	and (CDSActivityDate is not null or ReferralToTreatmentPeriodEndDate is not null)
 	and NHSNumber is not null
 group by NHSNumber

--- a/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthamticPatientRecord.cs
+++ b/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthamticPatientRecord.cs
@@ -1,0 +1,15 @@
+﻿using OmopTransformer.Annotations;
+
+namespace OmopTransformer.SUS.AE.Observation.AsthmaticPatient;
+
+[DataOrigin("SUS")]
+[Description("SUS AE Diabetic Patient")]
+[SourceQuery("SusAEAsthmaticPatient.xml")]
+internal class SusAEAsthmaticPatientRecord
+{
+    public string? NHSNumber { get; set; }
+    public string? GeneratedRecordIdentifier { get; set; }
+    public string? ArrivalDate { get; set; }
+    public string? ArrivalTime { get; set; }
+    public string? AccidentAndEmergencyDiagnosis { get; set; }
+}

--- a/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthmaticPatient.cs
+++ b/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthmaticPatient.cs
@@ -1,0 +1,34 @@
+﻿using OmopTransformer.Annotations;
+using OmopTransformer.Omop.Observation;
+using OmopTransformer.Transformation;
+
+namespace OmopTransformer.SUS.AE.Observation.AsthmaticPatient;
+
+[Notes(
+    "Notes",
+    "Observations do not require a standardized test or other activity to generate clinical fact. Typical observations are medical history, family history, lifestyle choices, healthcare utilization patterns, social circumstances etc",
+    "Valid Observation Concepts are not enforced to be from any domain.  They should still be standard concepts and typically belong to the Observation or Measurement domain.",
+    "Observations can be stored as attribute value pairs, with the attribute as the Observation Concept and the value representing the clinical fact. This fact can be stored as a Concept (value_as_concept), a numerical value (value_as_number) or a verbatim string (value_as_string)")]
+internal class SusAEAsthmaticPatient : OmopObservation<SusAEAsthmaticPatientRecord>
+{
+    [CopyValue(nameof(Source.NHSNumber))]
+    public override string? nhs_number { get; set; }
+
+    [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
+    public override string? RecordConnectionIdentifier { get; set; }
+
+    [ConstantValue(4233784, "Asthmatic bronchitis (disorder)")]
+    public override int? observation_concept_id { get; set; }
+
+    [Transform(typeof(DateConverter), nameof(Source.ArrivalDate))]
+    public override DateTime? observation_date { get; set; }
+
+    [Transform(typeof(DateAndTimeCombiner), nameof(Source.ArrivalDate), nameof(Source.ArrivalTime))]
+    public override DateTime? observation_datetime { get; set; }
+
+    [ConstantValue(32818, "EHR administration record")]
+    public override int? observation_type_concept_id { get; set; }
+
+    [CopyValue(nameof(Source.AccidentAndEmergencyDiagnosis))]
+    public override string? value_as_string { get; set; }
+}

--- a/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthmaticPatient.xml
+++ b/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthmaticPatient.xml
@@ -1,0 +1,44 @@
+﻿<Query>
+    <Sql>
+select
+	distinct
+		d.AccidentAndEmergencyDiagnosis,
+		ae.GeneratedRecordIdentifier,
+		ae.NHSNumber,
+		ae.ArrivalDate,
+		ae.ArrivalTime
+from omop_staging.sus_AE_diagnosis d
+	inner join omop_staging.sus_AE ae
+		on d.MessageId = ae.MessageId
+where ae.NHSNumber is not null
+and d.AccidentAndEmergencyDiagnosis in ('20','201')
+	</Sql>
+	<Explanations>
+		<Explanation columnName="NHSNumber">
+			<Description>Patient NHS Number</Description>
+			<Origin>NHS NUMBER</Origin>
+		</Explanation>
+		<Explanation columnName="GeneratedRecordIdentifier">
+			<Description>CDS specific identifier that binds multiple CDS messages together.</Description>
+			<Origin>CDS RECORD IDENTIFIER</Origin>
+		</Explanation>
+		<Explanation columnName="ArrivalDate">
+			<Description>Event date</Description>
+			<Origin>ARRIVAL DATE</Origin>
+		</Explanation>
+		<Explanation columnName="ArrivalTime">
+			<Description>The time (using a 24 hour clock) that is of relevance to an ACTIVITY.</Description>
+			<Origin>ARRIVAL TIME AT ACCIDENT AND EMERGENCY DEPARTMENT</Origin>
+		</Explanation>
+		<Explanation columnName="AccidentAndEmergencyDiagnosis">
+			<Description>
+				ACCIDENT AND EMERGENCY DIAGNOSIS is a six character code, comprising:
+					Diagnosis Condition	n2
+					Sub-Analysis	n1
+					ACCIDENT AND EMERGENCY ANATOMICAL AREA	n2
+					ACCIDENT AND EMERGENCY ANATOMICAL SIDE
+			</Description>
+			<Origin>PRIMARY DIAGNOSIS</Origin>
+		</Explanation>
+	</Explanations>
+</Query>

--- a/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatient.cs
+++ b/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatient.cs
@@ -1,0 +1,34 @@
+﻿using OmopTransformer.Annotations;
+using OmopTransformer.Omop.Observation;
+using OmopTransformer.Transformation;
+
+namespace OmopTransformer.SUS.AE.Observation.DiabeticPatient;
+
+[Notes(
+    "Notes",
+    "Observations do not require a standardized test or other activity to generate clinical fact. Typical observations are medical history, family history, lifestyle choices, healthcare utilization patterns, social circumstances etc",
+    "Valid Observation Concepts are not enforced to be from any domain.  They should still be standard concepts and typically belong to the Observation or Measurement domain.",
+    "Observations can be stored as attribute value pairs, with the attribute as the Observation Concept and the value representing the clinical fact. This fact can be stored as a Concept (value_as_concept), a numerical value (value_as_number) or a verbatim string (value_as_string)")]
+internal class SusAEDiabeticPatient : OmopObservation<SusAEDiabeticPatientRecord>
+{
+    [CopyValue(nameof(Source.NHSNumber))]
+    public override string? nhs_number { get; set; }
+
+    [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
+    public override string? RecordConnectionIdentifier { get; set; }
+
+    [ConstantValue(201820, "Diabetes mellitus (disorder)")]
+    public override int? observation_concept_id { get; set; }
+
+    [Transform(typeof(DateConverter), nameof(Source.ArrivalDate))]
+    public override DateTime? observation_date { get; set; }
+
+    [Transform(typeof(DateAndTimeCombiner), nameof(Source.ArrivalDate), nameof(Source.ArrivalTime))]
+    public override DateTime? observation_datetime { get; set; }
+
+    [ConstantValue(32818, "EHR administration record")]
+    public override int? observation_type_concept_id { get; set; }
+
+    [CopyValue(nameof(Source.AccidentAndEmergencyDiagnosis))]
+    public override string? value_as_string { get; set; }
+}

--- a/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatient.xml
+++ b/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatient.xml
@@ -1,0 +1,44 @@
+﻿<Query>
+    <Sql>
+select
+	distinct
+		d.AccidentAndEmergencyDiagnosis,
+		ae.GeneratedRecordIdentifier,
+		ae.NHSNumber,
+		ae.ArrivalDate,
+		ae.ArrivalTime
+from omop_staging.sus_AE_diagnosis d
+	inner join omop_staging.sus_AE ae
+		on d.MessageId = ae.MessageId
+where ae.NHSNumber is not null
+and d.AccidentAndEmergencyDiagnosis in ('30','301')
+	</Sql>
+	<Explanations>
+		<Explanation columnName="NHSNumber">
+			<Description>Patient NHS Number</Description>
+			<Origin>NHS NUMBER</Origin>
+		</Explanation>
+		<Explanation columnName="GeneratedRecordIdentifier">
+			<Description>CDS specific identifier that binds multiple CDS messages together.</Description>
+			<Origin>CDS RECORD IDENTIFIER</Origin>
+		</Explanation>
+		<Explanation columnName="ArrivalDate">
+			<Description>Event date</Description>
+			<Origin>ARRIVAL DATE</Origin>
+		</Explanation>
+		<Explanation columnName="ArrivalTime">
+			<Description>The time (using a 24 hour clock) that is of relevance to an ACTIVITY.</Description>
+			<Origin>ARRIVAL TIME AT ACCIDENT AND EMERGENCY DEPARTMENT</Origin>
+		</Explanation>
+		<Explanation columnName="AccidentAndEmergencyDiagnosis">
+			<Description>
+				ACCIDENT AND EMERGENCY DIAGNOSIS is a six character code, comprising:
+					Diagnosis Condition	n2
+					Sub-Analysis	n1
+					ACCIDENT AND EMERGENCY ANATOMICAL AREA	n2
+					ACCIDENT AND EMERGENCY ANATOMICAL SIDE
+			</Description>
+			<Origin>PRIMARY DIAGNOSIS</Origin>
+		</Explanation>
+	</Explanations>
+</Query>

--- a/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatientRecord.cs
+++ b/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatientRecord.cs
@@ -1,0 +1,15 @@
+﻿using OmopTransformer.Annotations;
+
+namespace OmopTransformer.SUS.AE.Observation.DiabeticPatient;
+
+[DataOrigin("SUS")]
+[Description("SUS AE Diabetic Patient")]
+[SourceQuery("SusAEDiabeticPatient.xml")]
+internal class SusAEDiabeticPatientRecord
+{
+    public string? NHSNumber { get; set; }
+    public string? GeneratedRecordIdentifier { get; set; }
+    public string? ArrivalDate { get; set; }
+    public string? ArrivalTime { get; set; }
+    public string? AccidentAndEmergencyDiagnosis { get; set; }
+}

--- a/OmopTransformer/SUS/AE/Observation/SourceOfReferralForOutpatients/SusAESourceOfReferralForOutpatients.cs
+++ b/OmopTransformer/SUS/AE/Observation/SourceOfReferralForOutpatients/SusAESourceOfReferralForOutpatients.cs
@@ -1,0 +1,34 @@
+﻿using OmopTransformer.Annotations;
+using OmopTransformer.Omop.Observation;
+using OmopTransformer.Transformation;
+
+namespace OmopTransformer.SUS.AE.Observation.SourceOfReferralForOutpatients;
+
+[Notes(
+    "Notes",
+    "Observations do not require a standardized test or other activity to generate clinical fact. Typical observations are medical history, family history, lifestyle choices, healthcare utilization patterns, social circumstances etc",
+    "Valid Observation Concepts are not enforced to be from any domain.  They should still be standard concepts and typically belong to the Observation or Measurement domain.",
+    "Observations can be stored as attribute value pairs, with the attribute as the Observation Concept and the value representing the clinical fact. This fact can be stored as a Concept (value_as_concept), a numerical value (value_as_number) or a verbatim string (value_as_string)")]
+internal class SusAESourceOfReferralForOutpatients : OmopObservation<SusAESourceOfReferralForOutpatientsRecord>
+{
+    [CopyValue(nameof(Source.NHSNumber))]
+    public override string? nhs_number { get; set; }
+
+    [CopyValue(nameof(Source.GeneratedRecordIdentifier))]
+    public override string? RecordConnectionIdentifier { get; set; }
+
+    [ConstantValue(4258129, "Referral by")]
+    public override int? observation_concept_id { get; set; }
+
+    [Transform(typeof(DateConverter), nameof(Source.ArrivalDate))]
+    public override DateTime? observation_date { get; set; }
+
+    [Transform(typeof(DateAndTimeCombiner), nameof(Source.ArrivalDate), nameof(Source.ArrivalTime))]
+    public override DateTime? observation_datetime { get; set; }
+
+    [ConstantValue(32818, "EHR administration record")]
+    public override int? observation_type_concept_id { get; set; }
+
+    [CopyValue(nameof(Source.SourceofReferralForAE))]
+    public override string? value_as_string { get; set; }
+}

--- a/OmopTransformer/SUS/AE/Observation/SourceOfReferralForOutpatients/SusAESourceOfReferralForOutpatients.xml
+++ b/OmopTransformer/SUS/AE/Observation/SourceOfReferralForOutpatients/SusAESourceOfReferralForOutpatients.xml
@@ -1,0 +1,34 @@
+﻿<Query>
+    <Sql>
+select
+	NHSNumber,
+	GeneratedRecordIdentifier,
+    ArrivalDate,
+    ArrivalTime,
+	SourceofReferralForAE   -- Referrer code is the code of the person making the referral request
+from omop_staging.sus_AE
+where SourceofReferralForAE is not null
+	</Sql>
+	<Explanations>
+		<Explanation columnName="NHSNumber">
+			<Description>Patient NHS Number</Description>
+			<Origin>NHS NUMBER</Origin>
+		</Explanation>
+		<Explanation columnName="GeneratedRecordIdentifier">
+			<Description>CDS specific identifier that binds multiple CDS messages together.</Description>
+			<Origin>CDS RECORD IDENTIFIER</Origin>
+		</Explanation>
+		<Explanation columnName="ArrivalDate">
+			<Description>Event date</Description>
+			<Origin>ARRIVAL DATE</Origin>
+		</Explanation>
+		<Explanation columnName="ArrivalTime">
+			<Description>The time (using a 24 hour clock) that is of relevance to an ACTIVITY.</Description>
+			<Origin>ARRIVAL TIME AT ACCIDENT AND EMERGENCY DEPARTMENT</Origin>
+		</Explanation>
+		<Explanation columnName="SourceofReferralForAE">
+			<Description>The source of referral of each Accident and Emergency Episode.</Description>
+			<Origin>SOURCE OF REFERRAL FOR A and E</Origin>
+		</Explanation>
+	</Explanations>
+</Query>

--- a/OmopTransformer/SUS/AE/Observation/SourceOfReferralForOutpatients/SusAESourceOfReferralForOutpatientsRecord.cs
+++ b/OmopTransformer/SUS/AE/Observation/SourceOfReferralForOutpatients/SusAESourceOfReferralForOutpatientsRecord.cs
@@ -1,0 +1,15 @@
+﻿using OmopTransformer.Annotations;
+
+namespace OmopTransformer.SUS.AE.Observation.SourceOfReferralForOutpatients;
+
+[DataOrigin("SUS")]
+[Description("SUS AE Source Of Referral For Outpatients")]
+[SourceQuery("SusAESourceOfReferralForOutpatients.xml")]
+internal class SusAESourceOfReferralForOutpatientsRecord
+{
+    public string? NHSNumber { get; set; }
+    public string? GeneratedRecordIdentifier { get; set; }
+    public string? ArrivalDate { get; set; }
+    public string? ArrivalTime { get; set; }
+    public string? SourceofReferralForAE { get; set; }
+}

--- a/OmopTransformer/SUS/AE/SusAETransformer.cs
+++ b/OmopTransformer/SUS/AE/SusAETransformer.cs
@@ -5,15 +5,10 @@ using OmopTransformer.SUS.AE.ConditionOccurrence;
 using OmopTransformer.SUS.AE.ProcedureOccurrence;
 // using OmopTransformer.SUS.AE.Measurements.SusAEMeasurement;
 using OmopTransformer.SUS.AE.VisitOccurrenceWithSpell;
-// using OmopTransformer.SUS.AE.Observation.AnaestheticDuringLabourDelivery;
-// using OmopTransformer.SUS.AE.Observation.AnaestheticGivenPostLabourDelivery;
-// using OmopTransformer.SUS.AE.Observation.BirthWeight;
-// using OmopTransformer.SUS.AE.Observation.CarerSupportIndicator;
-// using OmopTransformer.SUS.AE.Observation.GestationLengthLabourOnset;
-// using OmopTransformer.SUS.AE.Observation.NumberOfBabies;
-// using OmopTransformer.SUS.AE.Observation.TotalPreviousPregnancies;
-// using OmopTransformer.SUS.AE.Observation.SourceOfReferralForOutpatients;
-// using OmopTransformer.SUS.AE.VisitDetails;
+using OmopTransformer.SUS.AE.Observation.AsthmaticPatient;
+using OmopTransformer.SUS.AE.Observation.DiabeticPatient;
+using OmopTransformer.SUS.AE.Observation.SourceOfReferralForOutpatients;
+using OmopTransformer.SUS.AE.VisitDetails;
 // using OmopTransformer.SUS.AE.CareSite;
 // using OmopTransformer.SUS.AE.Provider;
 using OmopTransformer.Omop.ConditionOccurrence;
@@ -120,50 +115,25 @@ internal class SusAETransformer : Transformer
           "SUS AE VisitOccurrenceWithSpell",
           cancellationToken);
 
-        // await Transform<SusAEAnaestheticDuringLabourDeliveryRecord, SusAEAnaestheticDuringLabourDelivery>(
-        //   _observationRecorder.InsertUpdateObservations,
-        // "SUS AE AnaestheticDuringLabourDelivery",
-        //   cancellationToken);
+        await Transform<SusAEDiabeticPatientRecord, SusAEDiabeticPatient>(
+          _observationRecorder.InsertUpdateObservations,
+        "SUS AE DiabeticPatient",
+          cancellationToken);
 
-        // await Transform<SusAEAnaestheticGivenPostLabourDeliveryRecord, SusAEAnaestheticGivenPostLabourDelivery>(
-        //   _observationRecorder.InsertUpdateObservations,
-        //   "SUS AE AnaestheticGivenPostLabourDelivery",
-        //   cancellationToken);
+        await Transform<SusAEAsthmaticPatientRecord, SusAEAsthmaticPatient>(
+          _observationRecorder.InsertUpdateObservations,
+        "SUS AE AsthmaticPatient",
+          cancellationToken);
 
-        // await Transform<SusAEBirthWeightRecord, SusAEBirthWeight>(
-        //   _observationRecorder.InsertUpdateObservations,
-        //   "SUS AE BirthWeight",
-        //   cancellationToken);
+        await Transform<SusAESourceOfReferralForOutpatientsRecord, SusAESourceOfReferralForOutpatients>(
+          _observationRecorder.InsertUpdateObservations,
+          "SUS AE SourceOfReferralForOutpatients",
+          cancellationToken);
 
-        // await Transform<SusAECarerSupportIndicatorRecord, SusAECarerSupportIndicator>(
-        //   _observationRecorder.InsertUpdateObservations,
-        //   "SUS AE CarerSupportIndicator",
-        //   cancellationToken);
-
-        // await Transform<SusAEGestationLengthLabourOnsetRecord, SusAEGestationLengthLabourOnset>(
-        //   _observationRecorder.InsertUpdateObservations,
-        //   "SUS AE GestationLengthLabourOnset",
-        //   cancellationToken);
-
-        // await Transform<SusAENumberOfBabiesRecord, SusAENumberOfBabies>(
-        //   _observationRecorder.InsertUpdateObservations,
-        //   "SUS AE NumberOfBabies",
-        //   cancellationToken);
-
-        // await Transform<SusAETotalPreviousPregnanciesRecord, SusAETotalPreviousPregnancies>(
-        //   _observationRecorder.InsertUpdateObservations,
-        //   "SUS AE TotalPreviousPregnancies",
-        //   cancellationToken);
-
-        // await Transform<SusAESourceOfReferralForOutpatientsRecord, SusAESourceOfReferralForOutpatients>(
-        //   _observationRecorder.InsertUpdateObservations,
-        //   "SUS AE SourceOfReferralForOutpatients",
-        //   cancellationToken);
-
-        // await Transform<SusAEVisitDetailsRecord, SusAEVisitDetail>(
-        //   _visitDetailRecorder.InsertUpdateVisitDetail,
-        //   "SUS AE VisitDetail",
-        //   cancellationToken);
+        await Transform<SusAEVisitDetailsRecord, SusAEVisitDetail>(
+          _visitDetailRecorder.InsertUpdateVisitDetail,
+          "SUS AE VisitDetail",
+          cancellationToken);
 
         // await Transform<SusAECareSiteRecord, SusAECareSite>(
         //    _careSiteRecorder.InsertUpdateCareSite,

--- a/OmopTransformer/SUS/AE/VisitDetails/SusAEVisitDetail.cs
+++ b/OmopTransformer/SUS/AE/VisitDetails/SusAEVisitDetail.cs
@@ -1,0 +1,50 @@
+﻿using OmopTransformer.Annotations;
+using OmopTransformer.Omop.VisitDetail;
+using OmopTransformer.Transformation;
+
+namespace OmopTransformer.SUS.AE.VisitDetails;
+
+[Notes(
+    "Assumptions",
+    "* `Emergency` covers a visit to A&E within the given Hospital Provider, and hence covers Admission Code 21 and 24 only",
+    "* `Location Class` ID 24 is a Consultant Clinic within the Health Care Provider.",
+    "* `Patient Classification` ID 1 is the only entry that covers 24 hours or more with the use of a bed, and whilst others may be a day/night only, they will be discounted because they are less than 24 hours. Also, maternity is also not taken as an `Inpatient` visit.",
+    "* No calculations to be made between Start and end visit date to try to calculate 24 hours, but instead the `Patient Classification` will be sufficient")]
+internal class SusAEVisitDetail : OmopVisitDetail<SusAEVisitDetailsRecord>
+{
+    [CopyValue(nameof(Source.NHSNumber))]
+    public override string? nhs_number { get; set; }
+    
+    [CopyValue(nameof(Source.HospitalProviderSpellNumber))]
+    public override string? HospitalProviderSpellNumber { get; set; }
+
+    [Transform(typeof(DateConverter), nameof(Source.VisitStartDate))]
+    public override DateTime? visit_detail_start_date { get; set; }
+
+    [Transform(typeof(DateAndTimeCombiner), nameof(Source.VisitStartDate), nameof(Source.VisitStartTime))]
+    public override DateTime? visit_detail_start_datetime { get; set; }
+
+    [Transform(typeof(DateConverter), nameof(Source.VisitEndDate))]
+    public override DateTime? visit_detail_end_date { get; set; }
+
+    [Transform(typeof(DateAndTimeCombiner), nameof(Source.VisitEndDate), nameof(Source.VisitEndTime))]
+    public override DateTime? visit_detail_end_datetime { get; set; }
+
+    [ConstantValue(9201, "`Inpatient Visit`")] 
+    public override int? visit_detail_concept_id { get; set; }
+
+    [ConstantValue(32818, "`EHR administration record`")]
+    public override int? visit_detail_type_concept_id { get; set; }
+
+    [Transform(typeof(AdmittedSourceLookup), nameof(Source.SourceofAdmissionCode))]
+    public override int? admitted_from_concept_id { get; set; }
+
+    [CopyValue(nameof(Source.SourceofAdmissionCode))]
+    public override string? admitted_from_source_value { get; set; }
+
+    [Transform(typeof(DischargeDestinationLookup), nameof(Source.DischargeDestinationCode))]
+    public override int? discharged_to_concept_id { get; set; }
+
+    [CopyValue(nameof(Source.DischargeDestinationCode))]
+    public override string? discharged_to_source_value { get; set; }
+}

--- a/OmopTransformer/SUS/AE/VisitDetails/SusAEVisitDetails.xml
+++ b/OmopTransformer/SUS/AE/VisitDetails/SusAEVisitDetails.xml
@@ -1,0 +1,67 @@
+﻿<Query>
+    <Sql>
+
+	select  
+		ae.NHSNumber,
+		ae.AEAttendanceNumber,
+
+		coalesce(ae.ArrivalDate, ae.CDSActivityDate) as EpisodeStartDate,
+		coalesce(ae.ArrivalTime, '000000') as EpisodeStartTime,
+		coalesce(ae.AEDepartureDate, ae.AEAttendanceConclusionDate) as EpisodeEndDate,
+		coalesce(ae.AEDepartureTime, ae.AEAttendanceConclusionTime, '000000') as EpisodeEndTime,
+
+		ae.AEArrivalMode as SourceofAdmissionCode,
+		ae.AEAttendanceDisposal as DischargeDestinationCode
+
+	from omop_staging.sus_AE ae
+	where ae.NHSNumber is not null
+
+	</Sql>
+
+	<Explanations>
+		<Explanation columnName="NHSNumber">
+			<Description>Patient NHS Number</Description>
+			<Origin>NHS NUMBER</Origin>
+		</Explanation>
+		<Explanation columnName="HospitalProviderSpellNumber">
+			<Description>CDS specific hospital spell number that binds many episodes together.</Description>
+			<Origin>HOSPITAL PROVIDER SPELL NUMBER</Origin>
+		</Explanation>
+
+		<Explanation columnName="VisitStartDate">
+			<Description>Start date of the episode, if exists, else the start date of the spell.</Description>
+			<Origin>CDS ACTIVITY DATE</Origin>
+			<Origin>START DATE (HOSPITAL PROVIDER SPELL)</Origin>
+			<Origin>START DATE (EPISODE)</Origin>
+		</Explanation>
+
+		<Explanation columnName="VisitStartTime">
+			<Description>Start time of the episode, if exists, else midnight.</Description>
+			<Origin>START TIME (HOSPITAL PROVIDER SPELL)</Origin>
+			<Origin>START TIME (EPISODE)</Origin>
+		</Explanation>
+
+		<Explanation columnName="VisitEndDate">
+			<Description>End date of the episode, if exists, else the spell discharge date, if exists, else the message date.</Description>
+			<Origin>CDS ACTIVITY DATE</Origin>
+			<Origin>END DATE (EPISODE)</Origin>
+			<Origin>DISCHARGE DATE (HOSPITAL PROVIDER SPELL)</Origin>
+		</Explanation>
+
+		<Explanation columnName="VisitEndTime">
+			<Description>End time of the episode, if exists, else the spell discharge time, if exists, else the message date.</Description>
+			<Origin>DISCHARGE TIME (HOSPITAL PROVIDER SPELL)</Origin>
+			<Origin>END TIME (EPISODE)</Origin>
+		</Explanation>
+
+		<Explanation columnName="SourceofAdmissionCode">
+			<Description>Admission Source.</Description>
+			<Origin>ADMISSION SOURCE (HOSPITAL PROVIDER SPELL)</Origin>
+		</Explanation>
+
+		<Explanation columnName="DischargeDestinationCode">
+			<Description>Discharge Destination Code</Description>
+			<Origin>DISCHARGE DESTINATION CODE (HOSPITAL PROVIDER SPELL)</Origin>
+		</Explanation>
+	</Explanations>
+</Query>

--- a/OmopTransformer/SUS/AE/VisitDetails/SusAEVisitDetailsRecord.cs
+++ b/OmopTransformer/SUS/AE/VisitDetails/SusAEVisitDetailsRecord.cs
@@ -1,0 +1,18 @@
+﻿using OmopTransformer.Annotations;
+
+namespace OmopTransformer.SUS.AE.VisitDetails;
+
+[DataOrigin("SUS")]
+[Description("Sus Inptatient VisitDetails")]
+[SourceQuery("SusAEVisitDetails.xml")]
+internal class SusAEVisitDetailsRecord
+{
+    public string? NHSNumber { get; set; }
+    public string? HospitalProviderSpellNumber { get; set; }
+    public string? VisitStartDate { get; set; }
+    public string? VisitStartTime { get; set; }
+    public string? VisitEndDate { get; set; }
+    public string? VisitEndTime { get; set; }
+    public int? SourceofAdmissionCode { get; set; }
+    public int? DischargeDestinationCode { get; set; }
+}

--- a/OmopTransformer/SUS/AE/VisitOccurrenceWithSpell/SusAEVisitOccurrenceWithSpell.cs
+++ b/OmopTransformer/SUS/AE/VisitOccurrenceWithSpell/SusAEVisitOccurrenceWithSpell.cs
@@ -33,4 +33,15 @@ internal class SusAEVisitOccurrenceWithSpell : OmopVisitOccurrence<SusAEVisitOcc
     [ConstantValue(32818, "`EHR administration record`")]
     public override int? visit_type_concept_id { get; set; }
 
+    [Transform(typeof(AdmittedSourceLookup), nameof(Source.SourceofAdmissionCode))]
+    public override int? admitted_from_concept_id { get; set; }
+
+    [CopyValue(nameof(Source.SourceofAdmissionCode))]
+    public override string? admitted_from_source_value { get; set; }
+
+    [Transform(typeof(DischargeDestinationLookup), nameof(Source.DischargeDestinationCode))]
+    public override int? discharged_to_concept_id { get; set; }
+
+    [CopyValue(nameof(Source.DischargeDestinationCode))]
+    public override string? discharged_to_source_value { get; set; }
 }

--- a/OmopTransformer/SUS/AE/VisitOccurrenceWithSpell/SusAEVisitOccurrenceWithSpell.xml
+++ b/OmopTransformer/SUS/AE/VisitOccurrenceWithSpell/SusAEVisitOccurrenceWithSpell.xml
@@ -50,5 +50,15 @@
 			<Description>The latest episode end time for the spell, or midnight if none are specified.</Description>
 			<Origin>END TIME (EPISODE)</Origin>
 		</Explanation>
+
+		<Explanation columnName="SourceofAdmissionCode">
+			<Description>Admission Source.</Description>
+			<Origin>ADMISSION SOURCE (HOSPITAL PROVIDER SPELL)</Origin>
+		</Explanation>
+
+		<Explanation columnName="DischargeDestinationCode">
+			<Description>Discharge Destination Code</Description>
+			<Origin>DISCHARGE DESTINATION CODE (HOSPITAL PROVIDER SPELL)</Origin>
+		</Explanation>
 	</Explanations>
 </Query>

--- a/OmopTransformer/SUS/AE/VisitOccurrenceWithSpell/SusAEVisitOccurrenceWithSpellRecord.cs
+++ b/OmopTransformer/SUS/AE/VisitOccurrenceWithSpell/SusAEVisitOccurrenceWithSpellRecord.cs
@@ -13,4 +13,6 @@ internal class SusAEVisitOccurrenceWithSpellRecord
     public string? VisitStartTime { get; set; }
     public string? VisitEndDate { get; set; }
     public string? VisitEndTime { get; set; }
+    public string? SourceofAdmissionCode { get; set; }
+    public string? DischargeDestinationCode { get; set; }
 }

--- a/OmopTransformer/Transformation/AdmittedSourceLookup.cs
+++ b/OmopTransformer/Transformation/AdmittedSourceLookup.cs
@@ -8,6 +8,8 @@ internal class AdmittedSourceLookup : ILookup
     public Dictionary<string, ValueWithNote> Mappings { get; } =
         new()
         {
+            { "1", new ValueWithNote("38004353", "Ambulance") },
+            { "2", new ValueWithNote("",  "No mapping possible") },
             { "19", new ValueWithNote("581476", "Home Visit") },
             { "29", new ValueWithNote("8602",  "Temporary Lodging") },
             { "37", new ValueWithNote("38003619",  "Prison / Correctional Facility") },
@@ -29,6 +31,7 @@ internal class AdmittedSourceLookup : ILookup
 
     public string[] ColumnNotes =>
     [
-        "[Admission Source](https://www.datadictionary.nhs.uk/data_elements/admission_source__hospital_provider_spell_.html)"
+        "[Admission Source](https://www.datadictionary.nhs.uk/data_elements/admission_source__hospital_provider_spell_.html)",
+        "[Admission Source A&E](https://archive.datadictionary.nhs.uk/DD%20Release%20September%202020/attributes/accident_and_emergency_arrival_mode.html)"
     ];
 }

--- a/OmopTransformer/Transformation/DischargeDestinationLookup.cs
+++ b/OmopTransformer/Transformation/DischargeDestinationLookup.cs
@@ -8,6 +8,18 @@ internal class DischargeDestinationLookup : ILookup
     public Dictionary<string, ValueWithNote> Mappings { get; } =
         new()
         {
+            { "01", new ValueWithNote("8717", "In Patient Hospital") },
+            { "02", new ValueWithNote("581476", "Home Visit") },
+            { "03", new ValueWithNote("38004693", "Clinic or Group Practice") },
+            { "04", new ValueWithNote("8870", "Emergency Room - Hospital") },
+            { "05", new ValueWithNote("8870", "Emergency Room - Hospital") },
+            { "06", new ValueWithNote("8756", "Out Patient Hospital") },
+            { "07", new ValueWithNote("",     "No mapping possible") },
+            { "10", new ValueWithNote("",     "No mapping possible") },
+            { "11", new ValueWithNote("",     "No mapping possible") },
+            { "12", new ValueWithNote("",     "No mapping possible") },
+            { "13", new ValueWithNote("",     "No mapping possible") },
+            { "14", new ValueWithNote("",     "No mapping possible") },
             { "19", new ValueWithNote("581476", "Home Visit") },
             { "29", new ValueWithNote("8602",   "Temporary Lodging") },
             { "30", new ValueWithNote("38004284",   "Psychiatric Hospital") },
@@ -33,6 +45,7 @@ internal class DischargeDestinationLookup : ILookup
 
     public string[] ColumnNotes =>
     [
-        "[Discharge Destination](https://www.datadictionary.nhs.uk/data_elements/discharge_destination_code__hospital_provider_spell_.html)"
+        "[Discharge Destination](https://www.datadictionary.nhs.uk/data_elements/discharge_destination_code__hospital_provider_spell_.html)",
+        "[Discharge Destination A&E](https://archive.datadictionary.nhs.uk/DD%20Release%20September%202020/data_elements/accident_and_emergency_attendance_disposal_code.html)"
     ];
 }


### PR DESCRIPTION
**Changes:**

The way the A&E diagnosis codes are coded, you can extract patient who are diabetic or asthmatic (could be useful).

1. Added the following observations:
    * SourceOfReferralForOutpatients
    * AsthmaticPatient
    * DiabeticPatient


2. Whilst searching around admission/discharge codes there was an extra death code:

```
where ((ReferralToTreatmentPeriodStatus = 36) --PATIENT died before treatment
	or (AEPatientGroup = 70) -- PATIENT brought in dead
	or (AEAttendanceDisposal = 10))  --PATIENT died in AE
```


3. Turns out I never pushed `AE Visit Detail`, so included that, along with a change to `AE Visit Occurrence`.


4. Finally, the admission and discharge lookups have been updated to include A&E codes, no overlapping codes which I assume is a feature of the hospital admission and discharge coding in general.
 




