### PR TITLE
Feature/lookup miss logging

### DIFF
--- a/OmopTransformer/COSD/CosdTransformer.cs
+++ b/OmopTransformer/COSD/CosdTransformer.cs
@@ -88,7 +88,6 @@ internal class CosdTransformer : Transformer
 
     public CosdTransformer(
         IRecordTransformer recordTransformer, 
-        ILogger<IRecordTransformer> logger, 
         TransformOptions transformOptions, 
         IRecordProvider recordProvider, 
         ILocationRecorder locationRecorder, 
@@ -99,16 +98,17 @@ internal class CosdTransformer : Transformer
         IObservationRecorder observationRecorder, 
         IMeasurementRecorder measurementRecorder,
         IConceptMapper conceptMapper,
-        IRunAnalysisRecorder runAnalysisRecorder) 
+        IRunAnalysisRecorder runAnalysisRecorder,
+        ILoggerFactory loggerFactory) 
         : 
         base(
             recordTransformer, 
-            logger, 
             transformOptions, 
             recordProvider, 
             "COSD",
             conceptMapper,
-            runAnalysisRecorder)
+            runAnalysisRecorder,
+            loggerFactory)
     {
         _locationRecorder = locationRecorder;
         _personRecorder = personRecorder;

--- a/OmopTransformer/RTDS/RtdsTransformer.cs
+++ b/OmopTransformer/RTDS/RtdsTransformer.cs
@@ -14,21 +14,21 @@ internal class RtdsTransformer : Transformer
     
     public RtdsTransformer(
         IRecordTransformer recordTransformer, 
-        ILogger<IRecordTransformer> logger, 
         TransformOptions transformOptions, 
         IRecordProvider recordProvider, 
         ILocationRecorder locationRecorder, 
         IPersonRecorder personRecorder, 
         IConceptMapper conceptMapper,
-        IRunAnalysisRecorder runAnalysisRecorder) 
+        IRunAnalysisRecorder runAnalysisRecorder,
+        ILoggerFactory loggerFactory) 
         : base(
             recordTransformer, 
-            logger, 
             transformOptions, 
             recordProvider, 
             "RTDS",
             conceptMapper,
-            runAnalysisRecorder)
+            runAnalysisRecorder,
+            loggerFactory)
     {
         _locationRecorder = locationRecorder;
         _personRecorder = personRecorder;

--- a/OmopTransformer/SACT/SactTransformer.cs
+++ b/OmopTransformer/SACT/SactTransformer.cs
@@ -13,21 +13,21 @@ internal class SactTransformer : Transformer
     
     public SactTransformer(
         IRecordTransformer recordTransformer, 
-        ILogger<IRecordTransformer> logger, 
         TransformOptions transformOptions, 
         IRecordProvider recordProvider, 
         ILocationRecorder locationRecorder, 
         IPersonRecorder personRecorder, 
         IConceptMapper conceptMapper, 
-        IRunAnalysisRecorder runAnalysisRecorder) 
+        IRunAnalysisRecorder runAnalysisRecorder,
+        ILoggerFactory loggerFactory) 
         : base(
             recordTransformer, 
-            logger, 
             transformOptions, 
             recordProvider, 
             "SACT", 
             conceptMapper,
-            runAnalysisRecorder)
+            runAnalysisRecorder,
+            loggerFactory)
     {
         _locationRecorder = locationRecorder;
         _personRecorder = personRecorder;

--- a/OmopTransformer/SUS/AE/SusAETransformer.cs
+++ b/OmopTransformer/SUS/AE/SusAETransformer.cs
@@ -53,7 +53,6 @@ internal class SusAETransformer : Transformer
         IProviderRecorder providerRecorder,
         IMeasurementRecorder measurementRecorder,
         IRecordTransformer recordTransformer,
-        ILogger<IRecordTransformer> logger,
         TransformOptions transformOptions,
         IRecordProvider recordProvider,
         ILocationRecorder locationRecorder,
@@ -68,13 +67,14 @@ internal class SusAETransformer : Transformer
         IDeviceExposureRecorder deviceExposureRecorder,
         IObservationRecorder observationRecorder,
         IConceptMapper conceptMapper,
-        IRunAnalysisRecorder runAnalysisRecorder) : base(recordTransformer,
-        logger,
+        IRunAnalysisRecorder runAnalysisRecorder,
+        ILoggerFactory loggerFactory) : base(recordTransformer,
         transformOptions,
         recordProvider,
         "SUSAE",
         conceptMapper,
-        runAnalysisRecorder)
+        runAnalysisRecorder,
+        loggerFactory)
     {
         _locationRecorder = locationRecorder;
         _personRecorder = personRecorder;

--- a/OmopTransformer/SUS/APC/SusAPCTransformer.cs
+++ b/OmopTransformer/SUS/APC/SusAPCTransformer.cs
@@ -62,7 +62,6 @@ internal class SusAPCTransformer : Transformer
         IProviderRecorder providerRecorder,
         IMeasurementRecorder measurementRecorder,
         IRecordTransformer recordTransformer,
-        ILogger<IRecordTransformer> logger,
         TransformOptions transformOptions,
         IRecordProvider recordProvider,
         ILocationRecorder locationRecorder,
@@ -76,15 +75,16 @@ internal class SusAPCTransformer : Transformer
         IDeviceExposureRecorder deviceExposureRecorder,
         IObservationRecorder observationRecorder,
         IConceptMapper conceptMapper,
-        IRunAnalysisRecorder runAnalysisRecorder) :
+        IRunAnalysisRecorder runAnalysisRecorder,
+        ILoggerFactory loggerFactory) :
         base(
             recordTransformer,
-            logger,
             transformOptions,
             recordProvider,
             "SUSAPC",
             conceptMapper,
-            runAnalysisRecorder)
+            runAnalysisRecorder,
+            loggerFactory)
     {
         _locationRecorder = locationRecorder;
         _personRecorder = personRecorder;

--- a/OmopTransformer/SUS/OP/SusOPTransformer.cs
+++ b/OmopTransformer/SUS/OP/SusOPTransformer.cs
@@ -50,7 +50,6 @@ internal class SusOPTransformer : Transformer
         IProviderRecorder providerRecorder,
         IMeasurementRecorder measurementRecorder,
         IRecordTransformer recordTransformer,
-        ILogger<IRecordTransformer> logger,
         TransformOptions transformOptions,
         IRecordProvider recordProvider,
         ILocationRecorder locationRecorder,
@@ -64,13 +63,14 @@ internal class SusOPTransformer : Transformer
         IObservationRecorder observationRecorder,
         IDeviceExposureRecorder deviceExposureRecorder,
         IConceptMapper conceptMapper,
-        IRunAnalysisRecorder runAnalysisRecorder) : base(recordTransformer,
-        logger,
+        IRunAnalysisRecorder runAnalysisRecorder,
+        ILoggerFactory loggerFactory) : base(recordTransformer,
         transformOptions,
         recordProvider,
         "SUSOP",
         conceptMapper, 
-        runAnalysisRecorder)
+        runAnalysisRecorder,
+        loggerFactory)
     {
         _locationRecorder = locationRecorder;
         _personRecorder = personRecorder;

--- a/OmopTransformer/Transformation/IRecordTransformer.cs
+++ b/OmopTransformer/Transformation/IRecordTransformer.cs
@@ -1,8 +1,10 @@
-﻿using OmopTransformer.Omop;
+﻿using Microsoft.Extensions.Logging;
+using OmopTransformer.Omop;
 
 namespace OmopTransformer.Transformation;
 
 internal interface IRecordTransformer
 {
     void Transform<T>(IOmopRecord<T> record);
+    void PrintLogsAndResetLogger(ILoggerFactory loggerFactory);
 }

--- a/OmopTransformer/Transformation/RecordTransformLookupLogger.cs
+++ b/OmopTransformer/Transformation/RecordTransformLookupLogger.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace OmopTransformer.Transformation;
+
+internal class RecordTransformLookupLogger
+{
+    private readonly Dictionary<string, LookupMissCount> _missCountByLookup = new();
+    private readonly object _lock = new();
+
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _missCountByLookup.Clear();
+        }
+    }
+
+    public void Hit(string lookupName)
+    {
+        lock (_lock)
+        {
+            var counter = GetOrCreateMissCount(lookupName);
+
+            counter.Hit();
+        }
+    }
+
+    public void Miss(string lookupName, string value)
+    {
+        lock (_lock)
+        {
+            var counter = GetOrCreateMissCount(lookupName);
+
+            counter.Miss(value);
+        }
+    }
+
+    private LookupMissCount GetOrCreateMissCount(string lookupName)
+    {
+        if (_missCountByLookup.TryGetValue(lookupName, out var counter))
+        {
+            return counter;
+        }
+        else
+        {
+            var lookupCounter = new LookupMissCount();
+
+            _missCountByLookup.Add(lookupName, lookupCounter);
+
+            return lookupCounter;
+        }
+    }
+
+    public void PrintLog(ILoggerFactory loggerFactory)
+    {
+        lock (_lock)
+        {
+            if (ShouldPrintLog(_missCountByLookup) == false)
+                return;
+
+            var logger = loggerFactory.CreateLogger("LookupTransformer");
+
+            logger.LogWarning("Missed lookups");
+
+            foreach (var countByLookup in _missCountByLookup.OrderByDescending(count => count.Value.MissCount))
+            {
+                logger.LogWarning(" {0}", countByLookup.Key);
+
+                var missRatePercentage = (countByLookup.Value.MissCount * 100d) / (countByLookup.Value.MissCount + countByLookup.Value.HitCount);
+
+                logger
+                    .LogWarning(
+                        "     Total miss rate {0}% ({1} hits, {2} misses)",
+                        Math.Round(missRatePercentage, 2),
+                        countByLookup.Value.HitCount,
+                        countByLookup.Value.MissCount);
+
+                logger.LogWarning("       Misses");
+
+                foreach (var missCount in countByLookup.Value.MissCountByValue.OrderByDescending(count => count.Value))
+                {
+                    logger
+                        .LogWarning(
+                            "       - \"{0}\" misses: {1}",
+                            missCount.Key,
+                            missCount.Value);
+                }
+            }
+        }
+    }
+
+    private static bool ShouldPrintLog(Dictionary<string, LookupMissCount> lookupCounts) =>
+        lookupCounts
+            .Any(count => count.Value.MissCount > 0);
+
+    private class LookupMissCount
+    {
+        public int HitCount { get; private set; }
+        public int MissCount { get; private set; }
+
+        public readonly Dictionary<string, int> MissCountByValue = new();
+
+        public void Hit()
+        {
+            HitCount++;
+        }
+
+        public void Miss(string value)
+        {
+            MissCount++;
+
+            if (MissCountByValue.TryGetValue(value, out int count))
+            {
+                MissCountByValue[value] = ++count;
+            }
+            else
+            {
+                MissCountByValue.Add(value, value: 1);
+            }
+        }
+    }
+}

--- a/OmopTransformer/Transformation/RecordTransformLookupLogger.cs
+++ b/OmopTransformer/Transformation/RecordTransformLookupLogger.cs
@@ -60,7 +60,12 @@ internal class RecordTransformLookupLogger
 
             string logText = "Missed lookups" + Environment.NewLine;
 
-            foreach (var countByLookup in _missCountByLookup.OrderByDescending(count => count.Value.MissCount))
+            var missedLookupCounters =
+                _missCountByLookup
+                    .Where(counter => counter.Value.MissCount > 0)
+                    .OrderByDescending(count => count.Value.MissCount);
+
+            foreach (var countByLookup in missedLookupCounters)
             {
                 logText += $"Lookup name: {countByLookup.Key} {Environment.NewLine}";
 
@@ -72,6 +77,9 @@ internal class RecordTransformLookupLogger
 
                 foreach (var missCount in countByLookup.Value.MissCountByValue.OrderByDescending(count => count.Value))
                 {
+                    if (missCount.Value == 0)
+                        continue;
+
                     logText += $"  - \"{missCount.Key}\" misses: {missCount.Value}{Environment.NewLine}";
                 }
 

--- a/OmopTransformer/Transformation/RecordTransformer.cs
+++ b/OmopTransformer/Transformation/RecordTransformer.cs
@@ -168,8 +168,10 @@ internal class RecordTransformer : IRecordTransformer
                 }
             }
         }
-
-        _recordTransformLookupLogger.Miss(lookup, argument);
+        else
+        {
+            _recordTransformLookupLogger.Miss(lookup, argument);
+        }
     }
     
     private void TransformSelector<T>(IOmopRecord<T> record, TransformAttribute transformAttribute, PropertyInfo property, Type sourceType, bool sourceTypeAsOrigin)

--- a/OmopTransformer/Transformation/RecordTransformer.cs
+++ b/OmopTransformer/Transformation/RecordTransformer.cs
@@ -142,7 +142,7 @@ internal class RecordTransformer : IRecordTransformer
                     if (int.TryParse(value.Value, out int number))
                     {
                         property.SetValue(record, number);
-                        _recordTransformLookupLogger.Hit(nameof(lookup));
+                        _recordTransformLookupLogger.Hit(lookup);
                     }
                 }
                 else
@@ -155,12 +155,12 @@ internal class RecordTransformer : IRecordTransformer
                 if (property.PropertyType == typeof(string))
                 {
                     property.SetValue(record, value.Value);
-                    _recordTransformLookupLogger.Hit(nameof(lookup));
+                    _recordTransformLookupLogger.Hit(lookup);
                 }
                 else if (property.PropertyType == typeof(int))
                 {
                     property.SetValue(record, int.Parse(value.Value));
-                    _recordTransformLookupLogger.Hit(nameof(lookup));
+                    _recordTransformLookupLogger.Hit(lookup);
                 }
                 else
                 {
@@ -169,7 +169,7 @@ internal class RecordTransformer : IRecordTransformer
             }
         }
 
-        _recordTransformLookupLogger.Miss(nameof(lookup), argument);
+        _recordTransformLookupLogger.Miss(lookup, argument);
     }
     
     private void TransformSelector<T>(IOmopRecord<T> record, TransformAttribute transformAttribute, PropertyInfo property, Type sourceType, bool sourceTypeAsOrigin)

--- a/OmopTransformer/Transformation/RecordTransformer.cs
+++ b/OmopTransformer/Transformation/RecordTransformer.cs
@@ -14,6 +14,7 @@ internal class RecordTransformer : IRecordTransformer
     private readonly MeasurementMapsToValueResolver _relationshipResolver;
     private readonly Icd10NonStandardResolver _icd10NonStandardResolver;
     private readonly Icd10StandardResolver _icd10StandardResolver;
+    private readonly RecordTransformLookupLogger _recordTransformLookupLogger = new();
 
     public RecordTransformer(
         ILogger<RecordTransformer> logger, 
@@ -45,6 +46,12 @@ internal class RecordTransformer : IRecordTransformer
 
         TransformProperties(record, properties, sourceType, sourceTypeAsOrigin: false); // First run the transformations that refer to the source data from the database.
         TransformProperties(record, properties, sourceType, sourceTypeAsOrigin: true); // Then run transforms that use the results of the previous transformations, by referring to the content of the partially transformed record rather than the incoming database record.
+    }
+
+    public void PrintLogsAndResetLogger(ILoggerFactory loggerFactory)
+    {
+        _recordTransformLookupLogger.PrintLog(loggerFactory);
+        _recordTransformLookupLogger.Reset();
     }
 
     private void TransformProperties<T>(IOmopRecord<T> record, PropertyInfo[] properties, Type sourceType, bool sourceTypeAsOrigin)
@@ -135,6 +142,7 @@ internal class RecordTransformer : IRecordTransformer
                     if (int.TryParse(value.Value, out int number))
                     {
                         property.SetValue(record, number);
+                        _recordTransformLookupLogger.Hit(nameof(lookup));
                     }
                 }
                 else
@@ -147,10 +155,12 @@ internal class RecordTransformer : IRecordTransformer
                 if (property.PropertyType == typeof(string))
                 {
                     property.SetValue(record, value.Value);
+                    _recordTransformLookupLogger.Hit(nameof(lookup));
                 }
                 else if (property.PropertyType == typeof(int))
                 {
                     property.SetValue(record, int.Parse(value.Value));
+                    _recordTransformLookupLogger.Hit(nameof(lookup));
                 }
                 else
                 {
@@ -158,6 +168,8 @@ internal class RecordTransformer : IRecordTransformer
                 }
             }
         }
+
+        _recordTransformLookupLogger.Miss(nameof(lookup), argument);
     }
     
     private void TransformSelector<T>(IOmopRecord<T> record, TransformAttribute transformAttribute, PropertyInfo property, Type sourceType, bool sourceTypeAsOrigin)

--- a/OmopTransformer/Transformer.cs
+++ b/OmopTransformer/Transformer.cs
@@ -13,20 +13,22 @@ internal abstract class Transformer
     private readonly IRecordProvider _recordProvider;
     private readonly IConceptMapper _conceptMapper;
     private readonly IRunAnalysisRecorder _runAnalysisRecorder;
+    private readonly ILoggerFactory _loggerFactory;
 
     private bool _isConceptMapRendered = false;
 
     private readonly string _dataSource;
 
-    protected Transformer(IRecordTransformer recordTransformer, ILogger<IRecordTransformer> logger, TransformOptions transformOptions, IRecordProvider recordProvider, string dataSource, IConceptMapper conceptMapper, IRunAnalysisRecorder runAnalysisRecorder)
+    protected Transformer(IRecordTransformer recordTransformer, TransformOptions transformOptions, IRecordProvider recordProvider, string dataSource, IConceptMapper conceptMapper, IRunAnalysisRecorder runAnalysisRecorder, ILoggerFactory loggerFactory)
     {
         _recordTransformer = recordTransformer;
-        _logger = logger;
+        _logger = loggerFactory.CreateLogger<IRecordTransformer>();
         _transformOptions = transformOptions;
         _recordProvider = recordProvider;
         _dataSource = dataSource;
         _conceptMapper = conceptMapper;
         _runAnalysisRecorder = runAnalysisRecorder;
+        _loggerFactory = loggerFactory;
     }
 
     public async Task Transform<TSource, TTarget>(
@@ -109,6 +111,8 @@ internal abstract class Transformer
             "--------------------------------" + Environment.NewLine;
 
         _logger.LogInformation(text);
+
+        _recordTransformer.PrintLogsAndResetLogger(_loggerFactory);
     }
 
     private static string PerSecond(Stopwatch stopwatch, int total)


### PR DESCRIPTION
Added additional transformation logging to reveal occasions where we attempt to lookup a value but no mapping existed. Example output 
```
2025-05-29T15:17:40.8746313Z warn: LookupTransformer[0]
2025-05-29T15:17:40.8748572Z       Missed lookups
2025-05-29T15:17:40.8753060Z       Lookup name: NhsGenderLookup 
2025-05-29T15:17:40.8754023Z         Total miss rate 50% (121925 hits, 121927 misses)
2025-05-29T15:17:40.8754535Z         Misses
2025-05-29T15:17:40.8754987Z         - "2" misses: 65234
2025-05-29T15:17:40.8755447Z         - "1" misses: 56688
2025-05-29T15:17:40.8755861Z         - "9" misses: 3
2025-05-29T15:17:40.8756393Z         - "0" misses: 2
2025-05-29T15:17:40.8756790Z       
2025-05-29T15:17:40.8757164Z       Lookup name: RaceConceptLookup 
2025-05-29T15:17:40.8757665Z         Total miss rate 50% (121927 hits, 121927 misses)
2025-05-29T15:17:40.8758063Z         Misses
2025-05-29T15:17:40.8758477Z         - "A" misses: 79898
2025-05-29T15:17:40.8759037Z         - "Z" misses: 22544
2025-05-29T15:17:40.8759444Z         - "C" misses: 7459
2025-05-29T15:17:40.8759924Z         - "99" misses: 1798
2025-05-29T15:17:40.8760346Z         - "J" misses: 1600
2025-05-29T15:17:40.8760758Z         - "L" misses: 1321
2025-05-29T15:17:40.8761825Z         - "H" misses: 1221
2025-05-29T15:17:40.8762252Z         - "S" misses: 1037
2025-05-29T15:17:40.8762590Z         - "N" misses: 889
2025-05-29T15:17:40.8763920Z         - "B" misses: 716
2025-05-29T15:17:40.8764549Z         - "G" misses: 681
2025-05-29T15:17:40.8764918Z         - "F" misses: 539
2025-05-29T15:17:40.8765321Z         - "R" misses: 447
2025-05-29T15:17:40.8765639Z         - "D" misses: 431
2025-05-29T15:17:40.8766546Z         - "M" misses: 399
2025-05-29T15:17:40.8767010Z         - "P" misses: 338
2025-05-29T15:17:40.8767379Z         - "K" misses: 327
2025-05-29T15:17:40.8767704Z         - "E" misses: 282
2025-05-29T15:17:40.8768058Z       
2025-05-29T15:17:40.8768396Z       Lookup name: RaceSourceConceptLookup 
2025-05-29T15:17:40.8768925Z         Total miss rate 50% (121927 hits, 121927 misses)
2025-05-29T15:17:40.8769321Z         Misses
2025-05-29T15:17:40.8769651Z         - "A" misses: 79898
2025-05-29T15:17:40.8769997Z         - "Z" misses: 22544
2025-05-29T15:17:40.8770326Z         - "C" misses: 7459
2025-05-29T15:17:40.8770655Z         - "99" misses: 1798
2025-05-29T15:17:40.8770977Z         - "J" misses: 1600
2025-05-29T15:17:40.8771296Z         - "L" misses: 1321
2025-05-29T15:17:40.8771617Z         - "H" misses: 1221
2025-05-29T15:17:40.8771926Z         - "S" misses: 1037
2025-05-29T15:17:40.8772255Z         - "N" misses: 889
2025-05-29T15:17:40.8772573Z         - "B" misses: 716
2025-05-29T15:17:40.8773140Z         - "G" misses: 681
2025-05-29T15:17:40.8773447Z         - "F" misses: 539
2025-05-29T15:17:40.8773778Z         - "R" misses: 447
2025-05-29T15:17:40.8774081Z         - "D" misses: 431
2025-05-29T15:17:40.8774390Z         - "M" misses: 399
2025-05-29T15:17:40.8774699Z         - "P" misses: 338
2025-05-29T15:17:40.8775001Z         - "K" misses: 327
2025-05-29T15:17:40.8775323Z         - "E" misses: 282
```