### PR TITLE
Feature/many to one concept map

### DIFF
--- a/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrencePrimaryDiagnosis/CosdConditionOccurrencePrimaryDiagnosis.cs
+++ b/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrencePrimaryDiagnosis/CosdConditionOccurrencePrimaryDiagnosis.cs
@@ -29,7 +29,7 @@ internal class CosdConditionOccurrencePrimaryDiagnosis : OmopConditionOccurrence
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [CopyValue(nameof(Source.CancerDiagnosis))]
     public override string? condition_source_value { get; set; }

--- a/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrencePrimaryDiagnosisHistologyTopography/CosdConditionOccurrencePrimaryDiagnosisHistologyTopography.cs
+++ b/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrencePrimaryDiagnosisHistologyTopography/CosdConditionOccurrencePrimaryDiagnosisHistologyTopography.cs
@@ -30,7 +30,7 @@ internal class CosdConditionOccurrencePrimaryDiagnosisHistologyTopography : Omop
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(Icdo3Selector), nameof(Source.CancerHistology), nameof(Source.CancerTopography))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [Transform(typeof(TextDeliminator), nameof(Source.CancerHistology), nameof(Source.CancerTopography))]
     public override string? condition_source_value { get; set; }

--- a/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrenceProgression/CosdV9ConditionOccurrenceProgression.cs
+++ b/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrenceProgression/CosdV9ConditionOccurrenceProgression.cs
@@ -23,7 +23,7 @@ internal class CosdV9ConditionOccurrenceProgression : OmopConditionOccurrence<Co
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [CopyValue(nameof(Source.NonPrimaryProgressionOriginalDiagnosis))]
     public override string? condition_source_value { get; set; }

--- a/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrenceRecurrence/CosdV9ConditionOccurrenceRecurrence.cs
+++ b/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrenceRecurrence/CosdV9ConditionOccurrenceRecurrence.cs
@@ -23,7 +23,7 @@ internal class CosdV9ConditionOccurrenceRecurrence : OmopConditionOccurrence<Cos
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [CopyValue(nameof(Source.NonPrimaryRecurrenceOriginalDiagnosis))]
     public override string? condition_source_value { get; set; }

--- a/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrenceSecondaryDiagnosis/CosdV9ConditionOccurrenceSecondaryDiagnosis.cs
+++ b/OmopTransformer/COSD/ConditionOccurrence/CosdConditionOccurrenceSecondaryDiagnosis/CosdV9ConditionOccurrenceSecondaryDiagnosis.cs
@@ -19,7 +19,7 @@ internal class CosdV9ConditionOccurrenceSecondaryDiagnosis : OmopConditionOccurr
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [CopyValue(nameof(Source.SecondaryDiagnosis))]
     public override string? condition_source_value { get; set; }

--- a/OmopTransformer/COSD/ConditionOccurrence/CosdV8ConditionOccurrencePrimaryDiagnosis/CosdV8ConditionOccurrencePrimaryDiagnosis.cs
+++ b/OmopTransformer/COSD/ConditionOccurrence/CosdV8ConditionOccurrencePrimaryDiagnosis/CosdV8ConditionOccurrencePrimaryDiagnosis.cs
@@ -29,7 +29,7 @@ internal class CosdV8ConditionOccurrencePrimaryDiagnosis : OmopConditionOccurren
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [CopyValue(nameof(Source.CancerDiagnosis))]
     public override string? condition_source_value { get; set; }

--- a/OmopTransformer/COSD/ConditionOccurrence/CosdV8ConditionOccurrencePrimaryDiagnosisHistologyTopography/CosdV8ConditionOccurrencePrimaryDiagnosisHistologyTopography.cs
+++ b/OmopTransformer/COSD/ConditionOccurrence/CosdV8ConditionOccurrencePrimaryDiagnosisHistologyTopography/CosdV8ConditionOccurrencePrimaryDiagnosisHistologyTopography.cs
@@ -30,7 +30,7 @@ internal class CosdV8ConditionOccurrencePrimaryDiagnosisHistologyTopography : Om
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(Icdo3Selector), nameof(Source.CancerHistology), nameof(Source.CancerTopography))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [Transform(typeof(TextDeliminator), nameof(Source.CancerHistology), nameof(Source.CancerTopography))]
     public override string? condition_source_value { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementGradeOfDifferentiation/CosdV8MeasurementGradeOfDifferentiation.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementGradeOfDifferentiation/CosdV8MeasurementGradeOfDifferentiation.cs
@@ -22,5 +22,5 @@ internal class CosdV8MeasurementGradeOfDifferentiation : OmopMeasurement<CosdV8M
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(GradeDifferentiationLookup), nameof(Source.GradeOfDifferentiationAtDiagnosis))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementMcategoryFinalPreTreatmentStage/CosdV8MeasurementGradeOfDifferentiation.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementMcategoryFinalPreTreatmentStage/CosdV8MeasurementGradeOfDifferentiation.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementMcategoryFinalPreTreatmentStage : OmopMeasuremen
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MCategoryLookup), nameof(Source.McategoryFinalPreTreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500014, "MCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementMcategoryIntegratedStage/CosdV8MeasurementMcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementMcategoryIntegratedStage/CosdV8MeasurementMcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementMcategoryIntegratedStage : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MCategoryLookup), nameof(Source.MCategoryIntegratedStage))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500010, "MCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementNcategoryFinalPreTreatmentStage/CosdV8MeasurementNcategoryFinalPreTreatmentStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementNcategoryFinalPreTreatmentStage/CosdV8MeasurementNcategoryFinalPreTreatmentStage.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementNcategoryFinalPreTreatmentStage : OmopMeasuremen
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(NCategoryLookup), nameof(Source.NcategoryFinalPreTreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500015, "NCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementNcategoryIntegratedStage/CosdV8MeasurementNcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementNcategoryIntegratedStage/CosdV8MeasurementNcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementNcategoryIntegratedStage : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(NCategoryLookup), nameof(Source.NCategoryIntegratedStage))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500011, "NCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementNonPrimaryPathwayMetastasis/CosdV8MeasurementNonPrimaryPathwayMetastasis.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementNonPrimaryPathwayMetastasis/CosdV8MeasurementNonPrimaryPathwayMetastasis.cs
@@ -22,5 +22,5 @@ internal class CosdV8MeasurementNonPrimaryPathwayMetastasis : OmopMeasurement<Co
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MetastasisSiteLookup), nameof(Source.MetastaticSite))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementPrimaryPathwayMetastasis/CosdV8MeasurementPrimaryPathwayMetastasis.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementPrimaryPathwayMetastasis/CosdV8MeasurementPrimaryPathwayMetastasis.cs
@@ -22,5 +22,5 @@ internal class CosdV8MeasurementPrimaryPathwayMetastasis : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MetastasisSiteLookup), nameof(Source.MetastaticSite))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementSynchronousTumourIndicator/CosdV8MeasurementSynchronousTumourIndicator.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementSynchronousTumourIndicator/CosdV8MeasurementSynchronousTumourIndicator.cs
@@ -22,5 +22,5 @@ internal class CosdV8MeasurementSynchronousTumourIndicator : OmopMeasurement<Cos
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(SynchronousTumourLookup), nameof(Source.SynchronousTumourIndicator))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementTNMcategoryFinalPreTreatmentStage/CosdV8MeasurementTNMcategoryFinalPreTreatmentStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementTNMcategoryFinalPreTreatmentStage/CosdV8MeasurementTNMcategoryFinalPreTreatmentStage.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementTNMcategoryFinalPreTreatmentStage : OmopMeasurem
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TNMCategoryLookup), nameof(Source.TnmStageGroupingFinalPretreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500017, "TNMCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementTNMcategoryIntegratedStage/CosdV8MeasurementTNMcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementTNMcategoryIntegratedStage/CosdV8MeasurementTNMcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementTNMcategoryIntegratedStage : OmopMeasurement<Cos
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TNMCategoryLookup), nameof(Source.TnmStageGroupingIntegrated))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500013, "TNMCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementTcategoryFinalPreTreatmentStage/CosdV8MeasurementTcategoryFinalPreTreatmentStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementTcategoryFinalPreTreatmentStage/CosdV8MeasurementTcategoryFinalPreTreatmentStage.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementTcategoryFinalPreTreatmentStage : OmopMeasuremen
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TCategoryLookup), nameof(Source.TcategoryFinalPreTreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500016, "TCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementTcategoryIntegratedStage/CosdV8MeasurementTcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementTcategoryIntegratedStage/CosdV8MeasurementTcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementTcategoryIntegratedStage : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TCategoryLookup), nameof(Source.TCategoryIntegratedStage))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500012, "TCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementTumourHeightAboveAnalVerge/CosdV8MeasurementTumourHeightAboveAnalVerge.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementTumourHeightAboveAnalVerge/CosdV8MeasurementTumourHeightAboveAnalVerge.cs
@@ -22,7 +22,7 @@ internal class CosdV8MeasurementTumourHeightAboveAnalVerge : OmopMeasurement<Cos
     public override string? measurement_source_value { get; set; }
 
     [ConstantValue(3029142, "`Distance from anal verge`")]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(4172703, "`-`")]
     public override int? operator_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV8MeasurementTumourLaterality/CosdV8MeasurementTumourLaterality.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV8MeasurementTumourLaterality/CosdV8MeasurementTumourLaterality.cs
@@ -22,5 +22,5 @@ internal class CosdV8MeasurementTumourLaterality : OmopMeasurement<CosdV8Measure
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TumourLateralityLookup), nameof(Source.TumourLaterality))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementGradeOfDifferentiation/CosdV9MeasurementGradeOfDifferentiation.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementGradeOfDifferentiation/CosdV9MeasurementGradeOfDifferentiation.cs
@@ -22,5 +22,5 @@ internal class CosdV9MeasurementGradeOfDifferentiation : OmopMeasurement<CosdV9M
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(GradeDifferentiationLookup), nameof(Source.GradeOfDifferentiationAtDiagnosis))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementMcategoryFinalPreTreatmentStage/CosdV9MeasurementMcategoryFinalPreTreatmentStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementMcategoryFinalPreTreatmentStage/CosdV9MeasurementMcategoryFinalPreTreatmentStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementMcategoryFinalPreTreatmentStage : OmopMeasuremen
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MCategoryLookup), nameof(Source.McategoryFinalPreTreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500014, "MCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementMcategoryIntegratedStage/CosdV9MeasurementMcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementMcategoryIntegratedStage/CosdV9MeasurementMcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementMcategoryIntegratedStage : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MCategoryLookup), nameof(Source.MCategoryIntegratedStage))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500010, "MCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementNcategoryFinalPreTreatmentStage/CosdV9MeasurementNcategoryFinalPreTreatmentStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementNcategoryFinalPreTreatmentStage/CosdV9MeasurementNcategoryFinalPreTreatmentStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementNcategoryFinalPreTreatmentStage : OmopMeasuremen
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(NCategoryLookup), nameof(Source.NcategoryFinalPreTreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500015, "NCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementNcategoryIntegratedStage/CosdV9MeasurementNcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementNcategoryIntegratedStage/CosdV9MeasurementNcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementNcategoryIntegratedStage : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(NCategoryLookup), nameof(Source.NCategoryIntegratedStage))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500011, "NCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementNonPrimaryPathwayProgressionMetastasis/CosdV9MeasurementNonPrimaryPathwayProgressionMetastasis.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementNonPrimaryPathwayProgressionMetastasis/CosdV9MeasurementNonPrimaryPathwayProgressionMetastasis.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementNonPrimaryPathwayProgressionMetastasis : OmopMea
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MetastasisSiteLookup), nameof(Source.MetastaticSite))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500009, "NonPrimaryPathwayProgressionMetastasis")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementNonPrimaryPathwayRecurrenceMetastasis/CosdV9MeasurementNonPrimaryPathwayRecurrenceMetastasis.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementNonPrimaryPathwayRecurrenceMetastasis/CosdV9MeasurementNonPrimaryPathwayRecurrenceMetastasis.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementNonPrimaryPathwayRecurrenceMetastasis : OmopMeas
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MetastasisSiteLookup), nameof(Source.MetastaticSite))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500008, "NonPrimaryPathwayRecurrenceMetastasis")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementPrimaryPathwayMetastasis/CosdV9MeasurementPrimaryPathwayMetastasis.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementPrimaryPathwayMetastasis/CosdV9MeasurementPrimaryPathwayMetastasis.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementPrimaryPathwayMetastasis : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(MetastasisSiteLookup), nameof(Source.MetastaticSite))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500007, "PrimaryPathwayMetastasis")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementSynchronousTumourIndicator/CosdV9MeasurementSynchronousTumourIndicator.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementSynchronousTumourIndicator/CosdV9MeasurementSynchronousTumourIndicator.cs
@@ -22,5 +22,5 @@ internal class CosdV9MeasurementSynchronousTumourIndicator : OmopMeasurement<Cos
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(SynchronousTumourLookup), nameof(Source.SynchronousTumourIndicator))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementTNMcategoryFinalPreTreatmentStage/CosdV9MeasurementTNMcategoryFinalPreTreatmentStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementTNMcategoryFinalPreTreatmentStage/CosdV9MeasurementTNMcategoryFinalPreTreatmentStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementTNMcategoryFinalPreTreatmentStage : OmopMeasurem
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TNMCategoryLookup), nameof(Source.TnmStageGroupingFinalPretreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500017, "TNMCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementTNMcategoryIntegratedStage/CosdV9MeasurementTNMcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementTNMcategoryIntegratedStage/CosdV9MeasurementTNMcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementTNMcategoryIntegratedStage : OmopMeasurement<Cos
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TNMCategoryLookup), nameof(Source.TnmStageGroupingIntegrated))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500013, "TNMCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementTcategoryFinalPreTreatmentStage/CosdV9MeasurementTcategoryFinalPreTreatmentStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementTcategoryFinalPreTreatmentStage/CosdV9MeasurementTcategoryFinalPreTreatmentStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementTcategoryFinalPreTreatmentStage : OmopMeasuremen
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TCategoryLookup), nameof(Source.TcategoryFinalPreTreatment))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500016, "TCategoryFinalPreTreatmentStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementTcategoryIntegratedStage/CosdV9MeasurementTcategoryIntegratedStage.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementTcategoryIntegratedStage/CosdV9MeasurementTcategoryIntegratedStage.cs
@@ -22,7 +22,7 @@ internal class CosdV9MeasurementTcategoryIntegratedStage : OmopMeasurement<CosdV
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TCategoryLookup), nameof(Source.TCategoryIntegratedStage))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     [ConstantValue(2000500012, "TCategoryIntegratedStage")]
     public override int? measurement_source_concept_id { get; set; }

--- a/OmopTransformer/COSD/Measurements/CosdV9MeasurementTumourLaterality/CosdV9MeasurementTumourLaterality.cs
+++ b/OmopTransformer/COSD/Measurements/CosdV9MeasurementTumourLaterality/CosdV9MeasurementTumourLaterality.cs
@@ -22,5 +22,5 @@ internal class CosdV9MeasurementTumourLaterality : OmopMeasurement<CosdV9Measure
     public override string? measurement_source_value { get; set; }
 
     [Transform(typeof(TumourLateralityLookup), nameof(Source.TumourLaterality))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/COSD/Observation/CosdV8AdultComorbidityEvaluation/CosdV8AdultComorbidityEvaluation.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8AdultComorbidityEvaluation/CosdV8AdultComorbidityEvaluation.cs
@@ -11,7 +11,7 @@ internal class CosdV8AdultComorbidityEvaluation : OmopObservation<CosdV8AdultCom
     public override string? nhs_number { get; set; }
 
     [ConstantValue(40487424, "Adult comorbidity evaluation-27 score")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8AdultPerformanceStatus/CosdV8AdultPerformanceStatus.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8AdultPerformanceStatus/CosdV8AdultPerformanceStatus.cs
@@ -11,7 +11,7 @@ internal class CosdV8AdultPerformanceStatus : OmopObservation<CosdV8AdultPerform
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4309681, "General physical performance status")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8AlcoholHistoryCancerBeforeLastThreeMonths/CosdV8AlcoholHistoryCancerBeforeLastThreeMonths.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8AlcoholHistoryCancerBeforeLastThreeMonths/CosdV8AlcoholHistoryCancerBeforeLastThreeMonths.cs
@@ -11,7 +11,7 @@ internal class CosdV8AlcoholHistoryCancerBeforeLastThreeMonths : OmopObservation
     public override string? nhs_number { get; set; }
 
     [ConstantValue(35609491, "Alcohol units consumed per week")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8AlcoholHistoryCancerInLastThreeMonths/CosdV8AlcoholHistoryCancerInLastThreeMonths.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8AlcoholHistoryCancerInLastThreeMonths/CosdV8AlcoholHistoryCancerInLastThreeMonths.cs
@@ -11,7 +11,7 @@ internal class CosdV8AlcoholHistoryCancerInLastThreeMonths : OmopObservation<Cos
     public override string? nhs_number { get; set; }
 
     [ConstantValue(35609491, "Alcohol units consumed per week")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8FamilialCancerSyndromeIndicator/CosdV8FamilialCancerSyndromeIndicator.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8FamilialCancerSyndromeIndicator/CosdV8FamilialCancerSyndromeIndicator.cs
@@ -11,7 +11,7 @@ internal class CosdV8FamilialCancerSyndromeIndicator : OmopObservation<CosdV8Fam
     public override string? nhs_number { get; set; }
 
     [ConstantValue(44782478, "Hereditary cancer-predisposing syndrome")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8PersonStatedSexualOrientationCodeAtDiagnosis/CosdV8PersonStatedSexualOrientationCodeAtDiagnosis.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8PersonStatedSexualOrientationCodeAtDiagnosis/CosdV8PersonStatedSexualOrientationCodeAtDiagnosis.cs
@@ -11,7 +11,7 @@ internal class CosdV8PersonStatedSexualOrientationCodeAtDiagnosis : OmopObservat
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4036080, "Orientation of sexual relationship")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8SmokingStatusCode/CosdV8SmokingStatusCode.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8SmokingStatusCode/CosdV8SmokingStatusCode.cs
@@ -11,7 +11,7 @@ internal class CosdV8SmokingStatusCode : OmopObservation<CosdV8SmokingStatusCode
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4275495, "Tobacco smoking behavior - finding")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8SourceOfReferralForOutPatientsNonPrimaryCancerPathway/CosdV8SourceOfReferralForOutPatientsNonPrimaryCancerPathway.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8SourceOfReferralForOutPatientsNonPrimaryCancerPathway/CosdV8SourceOfReferralForOutPatientsNonPrimaryCancerPathway.cs
@@ -11,7 +11,7 @@ internal class CosdV8SourceOfReferralForOutPatientsNonPrimaryCancerPathway : Omo
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV8SourceOfReferralOutPatients/CosdV8SourceOfReferralOutPatients.cs
+++ b/OmopTransformer/COSD/Observation/CosdV8SourceOfReferralOutPatients/CosdV8SourceOfReferralOutPatients.cs
@@ -11,7 +11,7 @@ internal class CosdV8SourceOfReferralOutPatients : OmopObservation<CosdV8SourceO
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9AdultComorbidityEvaluation/CosdV9AdultComorbidityEvaluation.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9AdultComorbidityEvaluation/CosdV9AdultComorbidityEvaluation.cs
@@ -11,7 +11,7 @@ internal class CosdV9AdultComorbidityEvaluation : OmopObservation<CosdV9AdultCom
     public override string? nhs_number { get; set; }
 
     [ConstantValue(40487424, "Adult comorbidity evaluation-27 score")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9AsaScore/CosdV9AsaScore.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9AsaScore/CosdV9AsaScore.cs
@@ -11,7 +11,7 @@ internal class CosdV9AsaScore : OmopObservation<CosdV9AsaScoreRecord>
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4185914, "Identification of physical status")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9FamilialCancerSyndrome/CosdV9FamilialCancerSyndrome.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9FamilialCancerSyndrome/CosdV9FamilialCancerSyndrome.cs
@@ -11,7 +11,7 @@ internal class CosdV9FamilialCancerSyndrome : OmopObservation<CosdV9FamilialCanc
     public override string? nhs_number { get; set; }
 
     [ConstantValue(44782478, "Hereditary cancer-predisposing syndrome")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9FamilialCancerSyndromeSubsidiaryComment/CosdV9FamilialCancerSyndromeSubsidiaryComment.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9FamilialCancerSyndromeSubsidiaryComment/CosdV9FamilialCancerSyndromeSubsidiaryComment.cs
@@ -11,7 +11,7 @@ internal class CosdV9FamilialCancerSyndromeSubsidiaryComment : OmopObservation<C
     public override string? nhs_number { get; set; }
 
     [ConstantValue(44782478, "Hereditary cancer-predisposing syndrome")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9HistoryOfAlcoholCurrent/CosdV9HistoryOfAlcoholCurrent.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9HistoryOfAlcoholCurrent/CosdV9HistoryOfAlcoholCurrent.cs
@@ -11,7 +11,7 @@ internal class CosdV9HistoryOfAlcoholCurrent : OmopObservation<CosdV9HistoryOfAl
     public override string? nhs_number { get; set; }
 
     [ConstantValue(35609491, "Alcohol units consumed per week")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9HistoryOfAlcoholPast/CosdV9HistoryOfAlcoholPast.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9HistoryOfAlcoholPast/CosdV9HistoryOfAlcoholPast.cs
@@ -11,7 +11,7 @@ internal class CosdV9HistoryOfAlcoholPast : OmopObservation<CosdV9HistoryOfAlcoh
     public override string? nhs_number { get; set; }
 
     [ConstantValue(35609491, "Alcohol units consumed per week")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9MenopausalStatus/CosdV9MenopausalStatus.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9MenopausalStatus/CosdV9MenopausalStatus.cs
@@ -11,7 +11,7 @@ internal class CosdV9MenopausalStatus : OmopObservation<CosdV9MenopausalStatusRe
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4059477, "Menopause")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9PerformanceStatusAdult/CosdV9PerformanceStatusAdult.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9PerformanceStatusAdult/CosdV9PerformanceStatusAdult.cs
@@ -11,7 +11,7 @@ internal class CosdV9PerformanceStatusAdult : OmopObservation<CosdV9PerformanceS
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4309681, "General physical performance status")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9PersonSexualOrientationCodeAtDiagnosis/CosdV9PersonSexualOrientationCodeAtDiagnosis.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9PersonSexualOrientationCodeAtDiagnosis/CosdV9PersonSexualOrientationCodeAtDiagnosis.cs
@@ -11,7 +11,7 @@ internal class CosdV9PersonSexualOrientationCodeAtDiagnosis : OmopObservation<Co
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4036080, "Orientation of sexual relationship")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9SourceOfReferralForNonPrimaryCancerPathway/CosdV9SourceOfReferralForNonPrimaryCancerPathway.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9SourceOfReferralForNonPrimaryCancerPathway/CosdV9SourceOfReferralForNonPrimaryCancerPathway.cs
@@ -11,7 +11,7 @@ internal class CosdV9SourceOfReferralForNonPrimaryCancerPathway : OmopObservatio
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9SourceOfReferralForOutpatients/CosdV9SourceOfReferralForOutpatients.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9SourceOfReferralForOutpatients/CosdV9SourceOfReferralForOutpatients.cs
@@ -11,7 +11,7 @@ internal class CosdV9SourceOfReferralForOutpatients : OmopObservation<CosdV9Sour
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9TobaccoSmokingCessation/CosdV9TobaccoSmokingCessation.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9TobaccoSmokingCessation/CosdV9TobaccoSmokingCessation.cs
@@ -11,7 +11,7 @@ internal class CosdV9TobaccoSmokingCessation : OmopObservation<CosdV9TobaccoSmok
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4206526, "Smoking cessation behavior")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/Observation/CosdV9TobaccoSmokingStatus/CosdV9TobaccoSmokingStatus.cs
+++ b/OmopTransformer/COSD/Observation/CosdV9TobaccoSmokingStatus/CosdV9TobaccoSmokingStatus.cs
@@ -11,7 +11,7 @@ internal class CosdV9TobaccoSmokingStatus : OmopObservation<CosdV9TobaccoSmoking
     public override string? nhs_number { get; set; }
 
     [ConstantValue(4275495, "Tobacco smoking behavior - finding")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/COSD/ProcedureOccurrence/CosdV8ProcedureOccurrencePrimaryProcedureOpcs/CosdV8ProcedureOccurrencePrimaryProcedureOpcs.cs
+++ b/OmopTransformer/COSD/ProcedureOccurrence/CosdV8ProcedureOccurrencePrimaryProcedureOpcs/CosdV8ProcedureOccurrencePrimaryProcedureOpcs.cs
@@ -14,7 +14,7 @@ internal class CosdV8ProcedureOccurrencePrimaryProcedureOpcs : OmopProcedureOccu
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(Opcs4Selector), nameof(Source.PrimaryProcedureOpcs))]
     public override int? procedure_source_concept_id { set; get; }

--- a/OmopTransformer/COSD/ProcedureOccurrence/CosdV8ProcedureOccurrenceProcedureOpcs/CosdV8ProcedureOccurrenceProcedureOpcs.cs
+++ b/OmopTransformer/COSD/ProcedureOccurrence/CosdV8ProcedureOccurrenceProcedureOpcs/CosdV8ProcedureOccurrenceProcedureOpcs.cs
@@ -14,7 +14,7 @@ internal class CosdV8ProcedureOccurrenceProcedureOpcs : OmopProcedureOccurrence<
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(Opcs4Selector), nameof(Source.ProcedureOpcsCode))]
     public override int? procedure_source_concept_id { set; get; }

--- a/OmopTransformer/COSD/ProcedureOccurrence/CosdV9ProcedureOccurrencePrimaryProcedureOpcs/CosdV9ProcedureOccurrencePrimaryProcedureOpcs.cs
+++ b/OmopTransformer/COSD/ProcedureOccurrence/CosdV9ProcedureOccurrencePrimaryProcedureOpcs/CosdV9ProcedureOccurrencePrimaryProcedureOpcs.cs
@@ -14,7 +14,7 @@ internal class CosdV9ProcedureOccurrencePrimaryProcedureOpcs : OmopProcedureOccu
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(Opcs4Selector), nameof(Source.PrimaryProcedureOpcs))]
     public override int? procedure_source_concept_id { set; get; }

--- a/OmopTransformer/COSD/ProcedureOccurrence/CosdV9ProcedureOccurrenceProcedureOpcs/CosdV9ProcedureOccurrenceProcedureOpcs.cs
+++ b/OmopTransformer/COSD/ProcedureOccurrence/CosdV9ProcedureOccurrenceProcedureOpcs/CosdV9ProcedureOccurrenceProcedureOpcs.cs
@@ -14,7 +14,7 @@ internal class CosdV9ProcedureOccurrenceProcedureOpcs : OmopProcedureOccurrence<
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(Opcs4Selector), nameof(Source.ProcedureOpcsCode))]
     public override int? procedure_source_concept_id { set; get; }

--- a/OmopTransformer/ConceptResolver.cs
+++ b/OmopTransformer/ConceptResolver.cs
@@ -89,7 +89,7 @@ internal class ConceptResolver
         {
             return
                 value
-                    .Where(row => row.domain_id == null || row.domain_id!.Equals(domain, StringComparison.OrdinalIgnoreCase))
+                    .Where(row => domain == null || row.domain_id!.Equals(domain, StringComparison.OrdinalIgnoreCase))
                     .Select(row => row.target_concept_id)
                     .ToArray();
         }

--- a/OmopTransformer/ConceptResolver.cs
+++ b/OmopTransformer/ConceptResolver.cs
@@ -10,7 +10,7 @@ internal class ConceptResolver
     private readonly Configuration _configuration;
     private readonly ILogger<ConceptResolver> _logger;
 
-    private Dictionary<int, Row>? _mappings;
+    private Dictionary<int, IGrouping<int, Row>>? _mappings;
     private Dictionary<int, IReadOnlyCollection<int>>? _devicesByConceptId;
 
     private readonly object _loadingLock = new();
@@ -24,7 +24,7 @@ internal class ConceptResolver
         _configuration = configuration.Value;
     }
 
-    private Dictionary<int, Row> GetMappings()
+    private Dictionary<int, IGrouping<int, Row>> GetMappings()
     {
         _logger.LogInformation("Loading mappings codes.");
 
@@ -35,7 +35,8 @@ internal class ConceptResolver
         return
             connection
                 .Query<Row>(sql: "select * from omop_staging.concept_code_map")
-                .ToDictionary(row => row.source_concept_id!);
+                .GroupBy(row => row.source_concept_id!)
+                .ToDictionary(row => row.Key!);
     }
 
     private Dictionary<int, IReadOnlyCollection<int>> GetDevices()
@@ -80,16 +81,17 @@ internal class ConceptResolver
         }
     }
 
-    public int? GetConcept(int conceptId, string? domain)
+    public int[] GetConcepts(int conceptId, string? domain)
     {
         EnsureMapping();
 
         if (_mappings!.TryGetValue(conceptId, out var value))
         {
-            if (domain == null || value.domain_id!.Equals(domain, StringComparison.OrdinalIgnoreCase))
-                return value.target_concept_id;
-
-            return null;
+            return
+                value
+                    .Where(row => row.domain_id == null || row.domain_id!.Equals(domain, StringComparison.OrdinalIgnoreCase))
+                    .Select(row => row.target_concept_id)
+                    .ToArray();
         }
 
         lock (_unableToMapByFrequencyLock)
@@ -104,7 +106,7 @@ internal class ConceptResolver
             }
         }
 
-        return null;
+        return new int[] { };
     }
 
     public IReadOnlyCollection<int> GetConceptDevices(int conceptId)

--- a/OmopTransformer/ICD10ConceptLookup.cs
+++ b/OmopTransformer/ICD10ConceptLookup.cs
@@ -9,8 +9,6 @@ internal abstract class Icd10ConceptLookup : ConceptLookup
     {
     }
 
-    public override string LoadingLoggerMessage => "Loading ICD10 codes.";
-
     public override string FormatCode(string code) => TrimIcd10(code);
 
     internal static string TrimIcd10(string code)

--- a/OmopTransformer/Icd10NonStandardResolver.cs
+++ b/OmopTransformer/Icd10NonStandardResolver.cs
@@ -5,6 +5,9 @@ namespace OmopTransformer;
 
 internal class Icd10NonStandardResolver : Icd10ConceptLookup
 {
+    public override string LoadingLoggerMessage => "Loading ICD10 codes. (Icd10NonStandardResolver)";
+
+
     public Icd10NonStandardResolver(IOptions<Configuration> configuration, ILogger<ConceptLookup> logger) : base(configuration, logger)
     {
     }

--- a/OmopTransformer/Icd10StandardResolver.cs
+++ b/OmopTransformer/Icd10StandardResolver.cs
@@ -5,17 +5,20 @@ namespace OmopTransformer;
 
 internal class Icd10StandardResolver : Icd10ConceptLookup
 {
+    public override string LoadingLoggerMessage => "Loading ICD10 codes.";
+
     public Icd10StandardResolver(IOptions<Configuration> configuration, ILogger<ConceptLookup> logger) : base(configuration, logger)
     {
     }
 
     public override string Query =>
-        "select " +
-        "	ccm.target_concept_id as concept_id, " +
-        "	replace(ccm.source_concept_code, '.', '') as Code  " +
-        "from omop_staging.concept_code_map ccm " +
-        "	inner join cdm.concept c " +
-        "		on ccm.source_concept_id = c.concept_id " +
-        "where c.vocabulary_id = 'ICD10' ";
+        @"select
+	        max(ccm.target_concept_id) as concept_id, -- nominate one concept only
+	        replace(ccm.source_concept_code, '.', '') as Code 
+        from omop_staging.concept_code_map ccm 
+	        inner join cdm.concept c 
+		        on ccm.source_concept_id = c.concept_id 
+        where c.vocabulary_id = 'ICD10' 
+        group by source_concept_code";
 
 }

--- a/OmopTransformer/MeasurementMapsToValueResolver.cs
+++ b/OmopTransformer/MeasurementMapsToValueResolver.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Options;
 namespace OmopTransformer;
 internal class MeasurementMapsToValueResolver : Icd10ConceptLookup
 {
+    public override string LoadingLoggerMessage => "Loading ICD10 codes. (MeasurementMapsToValueResolver)";
+
     public MeasurementMapsToValueResolver(IOptions<Configuration> configuration, ILogger<ConceptLookup> logger) : base(configuration, logger)
     {
     }

--- a/OmopTransformer/Omop/ConditionOccurrence/ConditionOccurrenceRecorder.cs
+++ b/OmopTransformer/Omop/ConditionOccurrence/ConditionOccurrenceRecorder.cs
@@ -49,23 +49,26 @@ internal class ConditionOccurrenceRecorder : IConditionOccurrenceRecorder
                 if (record.IsValid == false)
                     continue;
 
-                dataTable.Rows.Add(
-                    record.nhs_number,
-                    record.RecordConnectionIdentifier,
-                    record.condition_concept_id,
-                    record.condition_start_date,
-                    record.condition_start_datetime,
-                    record.condition_end_date,
-                    record.condition_end_datetime,
-                    record.condition_type_concept_id,
-                    record.condition_status_concept_id,
-                    record.stop_reason,
-                    record.provider_id,
-                    record.visit_occurrence_id,
-                    record.visit_detail_id,
-                    record.condition_source_value,
-                    record.condition_source_concept_id,
-                    record.condition_status_source_value);
+                foreach (var conceptId in record.condition_concept_id!)
+                {
+                    dataTable.Rows.Add(
+                        record.nhs_number,
+                        record.RecordConnectionIdentifier,
+                        conceptId,
+                        record.condition_start_date,
+                        record.condition_start_datetime,
+                        record.condition_end_date,
+                        record.condition_end_datetime,
+                        record.condition_type_concept_id,
+                        record.condition_status_concept_id,
+                        record.stop_reason,
+                        record.provider_id,
+                        record.visit_occurrence_id,
+                        record.visit_detail_id,
+                        record.condition_source_value,
+                        record.condition_source_concept_id,
+                        record.condition_status_source_value);
+                }
             }
 
             var parameter = new

--- a/OmopTransformer/Omop/ConditionOccurrence/OmopConditionOccurrence.cs
+++ b/OmopTransformer/Omop/ConditionOccurrence/OmopConditionOccurrence.cs
@@ -4,7 +4,7 @@ internal abstract class OmopConditionOccurrence<T> : IOmopRecord<T>
 {
     public virtual string? nhs_number { get; set; }
     public virtual string? RecordConnectionIdentifier { get; set; }
-    public virtual int? condition_concept_id { get; set; }
+    public virtual int[]? condition_concept_id { get; set; }
     public virtual DateTime? condition_start_date { get; set; }
     public virtual DateTime? condition_start_datetime { get; set; }
     public virtual DateTime? condition_end_date { get; set; }

--- a/OmopTransformer/Omop/ConditionOccurrence/OmopConditionOccurrence.cs
+++ b/OmopTransformer/Omop/ConditionOccurrence/OmopConditionOccurrence.cs
@@ -24,6 +24,7 @@ internal abstract class OmopConditionOccurrence<T> : IOmopRecord<T>
 
     public virtual bool IsValid =>
         condition_concept_id != null &&
+        condition_concept_id.Any() &&
         condition_start_date.HasValue &&
         condition_type_concept_id != null &&
         nhs_number != null;

--- a/OmopTransformer/Omop/DrugExposure/DrugExposureRecorder.cs
+++ b/OmopTransformer/Omop/DrugExposure/DrugExposureRecorder.cs
@@ -54,28 +54,31 @@ internal class DrugExposureRecorder : IDrugExposureRecorder
                 if (record.IsValid == false)
                     continue;
 
-                dataTable.Rows.Add(
-                    record.nhs_number,
-                    record.drug_concept_id,
-                    record.drug_exposure_start_date,
-                    record.drug_exposure_start_datetime,
-                    record.drug_exposure_end_date,
-                    record.drug_exposure_end_datetime,
-                    record.verbatim_end_date,
-                    record.drug_type_concept_id,
-                    record.stop_reason,
-                    record.refills,
-                    record.quantity,
-                    record.days_supply,
-                    record.sig,
-                    record.route_concept_id,
-                    record.lot_number,
-                    record.provider_id,
-                    record.drug_source_value,
-                    record.drug_source_concept_id,
-                    record.route_source_value,
-                    record.dose_unit_source_value,
-                    record.RecordConnectionIdentifier);
+                foreach (var conceptId in record.drug_concept_id!)
+                {
+                    dataTable.Rows.Add(
+                        record.nhs_number,
+                        conceptId,
+                        record.drug_exposure_start_date,
+                        record.drug_exposure_start_datetime,
+                        record.drug_exposure_end_date,
+                        record.drug_exposure_end_datetime,
+                        record.verbatim_end_date,
+                        record.drug_type_concept_id,
+                        record.stop_reason,
+                        record.refills,
+                        record.quantity,
+                        record.days_supply,
+                        record.sig,
+                        record.route_concept_id,
+                        record.lot_number,
+                        record.provider_id,
+                        record.drug_source_value,
+                        record.drug_source_concept_id,
+                        record.route_source_value,
+                        record.dose_unit_source_value,
+                        record.RecordConnectionIdentifier);
+                }
             }
 
             var parameter = new

--- a/OmopTransformer/Omop/DrugExposure/OmopDrugExposure.cs
+++ b/OmopTransformer/Omop/DrugExposure/OmopDrugExposure.cs
@@ -3,7 +3,7 @@
 internal abstract class OmopDrugExposure<T> : IOmopRecord<T>
 {
     public virtual string? nhs_number { get; set; }
-    public virtual int? drug_concept_id { get; set; }
+    public virtual int[]? drug_concept_id { get; set; }
     public virtual DateTime? drug_exposure_start_date { get; set; }
     public virtual DateTime? drug_exposure_start_datetime { get; set; }
     public virtual DateTime? drug_exposure_end_date { get; set; }

--- a/OmopTransformer/Omop/DrugExposure/OmopDrugExposure.cs
+++ b/OmopTransformer/Omop/DrugExposure/OmopDrugExposure.cs
@@ -28,6 +28,7 @@ internal abstract class OmopDrugExposure<T> : IOmopRecord<T>
 
     public virtual bool IsValid =>
         drug_concept_id != null &&
+        drug_concept_id.Any() &&
         drug_exposure_end_date.HasValue &&
         drug_exposure_start_date.HasValue &&
         drug_type_concept_id != null &&

--- a/OmopTransformer/Omop/Measurement/MeasurementRecorder.cs
+++ b/OmopTransformer/Omop/Measurement/MeasurementRecorder.cs
@@ -55,29 +55,32 @@ internal class MeasurementRecorder : IMeasurementRecorder
                 if (record.IsValid == false)
                     continue;
 
-                dataTable.Rows.Add(
-                    record.nhs_number,
-                    record.measurement_concept_id,
-                    record.measurement_date,
-                    record.measurement_datetime,
-                    record.measurement_time,
-                    record.measurement_type_concept_id,
-                    record.operator_concept_id,
-                    record.value_as_number,
-                    record.value_as_concept_id,
-                    record.unit_concept_id,
-                    record.range_low,
-                    record.range_high,
-                    record.provider_id,
-                    record.measurement_source_value,
-                    record.measurement_source_concept_id,
-                    record.unit_source_value,
-                    record.unit_source_concept_id,
-                    record.value_source_value,
-                    record.measurement_event_id,
-                    record.meas_event_field_concept_id,
-                    record.RecordConnectionIdentifier,
-                    record.HospitalProviderSpellNumber);
+                foreach (var conceptId in record.measurement_concept_id!)
+                {
+                    dataTable.Rows.Add(
+                        record.nhs_number,
+                        conceptId,
+                        record.measurement_date,
+                        record.measurement_datetime,
+                        record.measurement_time,
+                        record.measurement_type_concept_id,
+                        record.operator_concept_id,
+                        record.value_as_number,
+                        record.value_as_concept_id,
+                        record.unit_concept_id,
+                        record.range_low,
+                        record.range_high,
+                        record.provider_id,
+                        record.measurement_source_value,
+                        record.measurement_source_concept_id,
+                        record.unit_source_value,
+                        record.unit_source_concept_id,
+                        record.value_source_value,
+                        record.measurement_event_id,
+                        record.meas_event_field_concept_id,
+                        record.RecordConnectionIdentifier,
+                        record.HospitalProviderSpellNumber);
+                }
             }
 
             var parameter = new

--- a/OmopTransformer/Omop/Measurement/OmopMeasurement.cs
+++ b/OmopTransformer/Omop/Measurement/OmopMeasurement.cs
@@ -29,6 +29,7 @@ internal abstract class OmopMeasurement<T> : IOmopRecord<T>
 
     public virtual bool IsValid =>
         measurement_concept_id != null &&
+        measurement_concept_id.Any() &&
         measurement_date.HasValue &&
         nhs_number != null &&
         measurement_type_concept_id != null;

--- a/OmopTransformer/Omop/Measurement/OmopMeasurement.cs
+++ b/OmopTransformer/Omop/Measurement/OmopMeasurement.cs
@@ -3,7 +3,7 @@
 internal abstract class OmopMeasurement<T> : IOmopRecord<T>
 {
     public virtual string? nhs_number { get; set; }
-    public virtual int? measurement_concept_id { get; set; }
+    public virtual int[]? measurement_concept_id { get; set; }
     public virtual DateTime? measurement_date { get; set; }
     public virtual DateTime? measurement_datetime { get; set; }
     public virtual DateTime? measurement_time { get; set; }

--- a/OmopTransformer/Omop/Observation/ObservationRecorder.cs
+++ b/OmopTransformer/Omop/Observation/ObservationRecorder.cs
@@ -53,27 +53,30 @@ internal class ObservationRecorder : IObservationRecorder
                 if (record.IsValid == false)
                     continue;
 
-                dataTable.Rows.Add(
-                    record.nhs_number,
-                    record.RecordConnectionIdentifier,
-                    record.HospitalProviderSpellNumber,
-                    record.observation_concept_id,
-                    record.observation_date,
-                    record.observation_datetime,
-                    record.observation_type_concept_id,
-                    record.value_as_number,
-                    record.value_as_string,
-                    record.value_as_concept_id,
-                    record.qualifier_concept_id,
-                    record.unit_concept_id,
-                    record.provider_id,
-                    record.observation_source_value,
-                    record.observation_source_concept_id,
-                    record.unit_source_value,
-                    record.qualifier_source_value,
-                    record.value_source_value,
-                    record.observation_event_id,
-                    record.obs_event_field_concept_id);
+                foreach (var conceptId in record.observation_concept_id!)
+                {
+                    dataTable.Rows.Add(
+                        record.nhs_number,
+                        record.RecordConnectionIdentifier,
+                        record.HospitalProviderSpellNumber,
+                        conceptId,
+                        record.observation_date,
+                        record.observation_datetime,
+                        record.observation_type_concept_id,
+                        record.value_as_number,
+                        record.value_as_string,
+                        record.value_as_concept_id,
+                        record.qualifier_concept_id,
+                        record.unit_concept_id,
+                        record.provider_id,
+                        record.observation_source_value,
+                        record.observation_source_concept_id,
+                        record.unit_source_value,
+                        record.qualifier_source_value,
+                        record.value_source_value,
+                        record.observation_event_id,
+                        record.obs_event_field_concept_id);
+                }
             }
 
             var parameter = new

--- a/OmopTransformer/Omop/Observation/OmopObservation.cs
+++ b/OmopTransformer/Omop/Observation/OmopObservation.cs
@@ -27,6 +27,7 @@ internal abstract class OmopObservation<T> : IOmopRecord<T>
 
     public virtual bool IsValid =>
         observation_concept_id != null &&
+        observation_concept_id.Any() &&
         observation_date.HasValue &&
         nhs_number != null &&
         observation_type_concept_id != null;

--- a/OmopTransformer/Omop/Observation/OmopObservation.cs
+++ b/OmopTransformer/Omop/Observation/OmopObservation.cs
@@ -5,7 +5,7 @@ internal abstract class OmopObservation<T> : IOmopRecord<T>
     public virtual string? nhs_number { get; set; }
     public virtual string? RecordConnectionIdentifier { get; set; }
     public virtual string? HospitalProviderSpellNumber { get; set; }
-    public virtual int? observation_concept_id { get; set; }
+    public virtual int[]? observation_concept_id { get; set; }
     public virtual DateTime? observation_date { get; set; }
     public virtual DateTime? observation_datetime { get; set; }
     public virtual int? observation_type_concept_id { get; set; }

--- a/OmopTransformer/Omop/ProcedureOccurrence/OmopProcedureOccurrence.cs
+++ b/OmopTransformer/Omop/ProcedureOccurrence/OmopProcedureOccurrence.cs
@@ -3,7 +3,7 @@
 internal abstract class OmopProcedureOccurrence<T> : IOmopRecord<T>
 {
     public virtual string? nhs_number { get; set; }
-    public virtual int? procedure_concept_id { get; set; }
+    public virtual int[]? procedure_concept_id { get; set; }
     public virtual DateTime? procedure_date { get; set; }
     public virtual DateTime? procedure_datetime { get; set; }
     public virtual DateTime? procedure_end_date { get; set; }

--- a/OmopTransformer/Omop/ProcedureOccurrence/OmopProcedureOccurrence.cs
+++ b/OmopTransformer/Omop/ProcedureOccurrence/OmopProcedureOccurrence.cs
@@ -25,6 +25,7 @@ internal abstract class OmopProcedureOccurrence<T> : IOmopRecord<T>
     public virtual bool IsValid =>
         nhs_number != null &&
         procedure_concept_id != null &&
+        procedure_concept_id.Any() &&
         procedure_date.HasValue &&
         procedure_type_concept_id != null;
 }

--- a/OmopTransformer/Omop/ProcedureOccurrence/ProcedureOccurrenceRecorder.cs
+++ b/OmopTransformer/Omop/ProcedureOccurrence/ProcedureOccurrenceRecorder.cs
@@ -49,23 +49,26 @@ internal class ProcedureOccurrenceRecorder : IProcedureOccurrenceRecorder
                 if (record.IsValid == false)
                     continue;
 
-                dataTable.Rows.Add(
-                    record.nhs_number,
-                    record.procedure_concept_id,
-                    record.procedure_date,
-                    record.procedure_datetime,
-                    record.procedure_end_date,
-                    record.procedure_end_datetime,
-                    record.procedure_type_concept_id,
-                    record.modifier_concept_id,
-                    record.quantity,
-                    record.provider_id,
-                    record.visit_occurrence_id,
-                    record.visit_detail_id,
-                    record.procedure_source_value,
-                    record.procedure_source_concept_id,
-                    record.modifier_source_value,
-                    record.RecordConnectionIdentifier);
+                foreach (var conceptId in record.procedure_concept_id!)
+                {
+                    dataTable.Rows.Add(
+                        record.nhs_number,
+                        conceptId,
+                        record.procedure_date,
+                        record.procedure_datetime,
+                        record.procedure_end_date,
+                        record.procedure_end_datetime,
+                        record.procedure_type_concept_id,
+                        record.modifier_concept_id,
+                        record.quantity,
+                        record.provider_id,
+                        record.visit_occurrence_id,
+                        record.visit_detail_id,
+                        record.procedure_source_value,
+                        record.procedure_source_concept_id,
+                        record.modifier_source_value,
+                        record.RecordConnectionIdentifier);
+                }
             }
 
             var parameter = new

--- a/OmopTransformer/OxfordGP/ConditionOccurrence/OxfordGPConditionOccurrence.cs
+++ b/OmopTransformer/OxfordGP/ConditionOccurrence/OxfordGPConditionOccurrence.cs
@@ -13,7 +13,7 @@ internal class OxfordGPConditionOccurrence : OmopConditionOccurrence<OxfordGPCon
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.EventDate))]
     public override DateTime? condition_start_date { get; set; }

--- a/OmopTransformer/OxfordGP/ProcedureOccurrence/OxfordGPProcedureOccurrence.cs
+++ b/OmopTransformer/OxfordGP/ProcedureOccurrence/OxfordGPProcedureOccurrence.cs
@@ -10,7 +10,7 @@ internal class OxfordGPProcedureOccurrence : OmopProcedureOccurrence<OxfordGPPro
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.EventDate))]
     public override DateTime? procedure_date { get; set; }

--- a/OmopTransformer/SACT/ConditionOccurrence/SactConditionOccurrence.cs
+++ b/OmopTransformer/SACT/ConditionOccurrence/SactConditionOccurrence.cs
@@ -13,7 +13,7 @@ internal class SactConditionOccurrence : OmopConditionOccurrence<SactConditionOc
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Administration_Date))]
     public override DateTime? condition_start_date { get; set; }

--- a/OmopTransformer/SACT/DrugExposure/SactDrugExposure.cs
+++ b/OmopTransformer/SACT/DrugExposure/SactDrugExposure.cs
@@ -10,7 +10,7 @@ internal class SactDrugExposure : OmopDrugExposure<SactDrugExposureRecord>
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardDrugConceptSelector), useOmopTypeAsSource: true, nameof(drug_source_concept_id))]
-    public override int? drug_concept_id { get; set; }
+    public override int[]? drug_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.Administration_Date))]
     public override DateTime? drug_exposure_start_date { get; set; }

--- a/OmopTransformer/SUS/AE/ConditionOccurrence/SusAEConditionOccurrence.cs
+++ b/OmopTransformer/SUS/AE/ConditionOccurrence/SusAEConditionOccurrence.cs
@@ -13,7 +13,7 @@ internal class SusAEConditionOccurrence : OmopConditionOccurrence<SusAECondition
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.CDSActivityDate))]
     public override DateTime? condition_start_date { get; set; }

--- a/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthmaticPatient.cs
+++ b/OmopTransformer/SUS/AE/Observation/AsthmaticPatient/SusAEAsthmaticPatient.cs
@@ -18,7 +18,7 @@ internal class SusAEAsthmaticPatient : OmopObservation<SusAEAsthmaticPatientReco
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(4233784, "Asthmatic bronchitis (disorder)")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.ArrivalDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatient.cs
+++ b/OmopTransformer/SUS/AE/Observation/DiabeticPatient/SusAEDiabeticPatient.cs
@@ -18,7 +18,7 @@ internal class SusAEDiabeticPatient : OmopObservation<SusAEDiabeticPatientRecord
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(201820, "Diabetes mellitus (disorder)")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.ArrivalDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/AE/Observation/SourceOfReferralForAE/SusAESourceOfReferralForAE.cs
+++ b/OmopTransformer/SUS/AE/Observation/SourceOfReferralForAE/SusAESourceOfReferralForAE.cs
@@ -18,7 +18,7 @@ internal class SusAESourceOfReferralForAE : OmopObservation<SusAESourceOfReferra
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.ArrivalDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/AE/ProcedureOccurrence/SusAEProcedureOccurrence.cs
+++ b/OmopTransformer/SUS/AE/ProcedureOccurrence/SusAEProcedureOccurrence.cs
@@ -10,7 +10,7 @@ internal class SusAEProcedureOccurrence : OmopProcedureOccurrence<SusAEProcedure
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.PrimaryProcedureDate))]
     public override DateTime? procedure_date { get; set; }

--- a/OmopTransformer/SUS/APC/ConditionOccurrence/SusAPCConditionOccurrence.cs
+++ b/OmopTransformer/SUS/APC/ConditionOccurrence/SusAPCConditionOccurrence.cs
@@ -13,7 +13,7 @@ internal class SusAPCConditionOccurrence : OmopConditionOccurrence<SusAPCConditi
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.CDSActivityDate))]
     public override DateTime? condition_start_date { get; set; }

--- a/OmopTransformer/SUS/APC/Measurements/SusAPCMeasurement.cs
+++ b/OmopTransformer/SUS/APC/Measurements/SusAPCMeasurement.cs
@@ -28,5 +28,5 @@ internal class SusAPCMeasurement : OmopMeasurement<SusAPCMeasurementRecord>
     public override string? value_source_value { get; set; }
 
     [Transform(typeof(StandardMeasurementConceptSelector), useOmopTypeAsSource: true, nameof(measurement_source_concept_id))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 }

--- a/OmopTransformer/SUS/APC/Observation/AnaestheticDuringLabourDelivery/SusAPCAnaestheticDuringLabourDelivery.cs
+++ b/OmopTransformer/SUS/APC/Observation/AnaestheticDuringLabourDelivery/SusAPCAnaestheticDuringLabourDelivery.cs
@@ -21,7 +21,7 @@ internal class SusAPCAnaestheticDuringLabourDelivery : OmopObservation<SusAPCAna
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4163264, "Type of anesthetic")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.observation_date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/AnaestheticGivenPostLabourDelivery/SusAPCAnaestheticGivenPostLabourDelivery.cs
+++ b/OmopTransformer/SUS/APC/Observation/AnaestheticGivenPostLabourDelivery/SusAPCAnaestheticGivenPostLabourDelivery.cs
@@ -21,7 +21,7 @@ internal class SusAPCAnaestheticGivenPostLabourDelivery : OmopObservation<SusAPC
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4163264, "Type of anesthetic")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.observation_date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/BirthWeight/SusAPCBirthWeight.cs
+++ b/OmopTransformer/SUS/APC/Observation/BirthWeight/SusAPCBirthWeight.cs
@@ -21,7 +21,7 @@ internal class SusAPCBirthWeight : OmopObservation<SusAPCBirthWeightRecord>
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(3662222, "Weight of neonate at birth")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.observation_date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/CarerSupportIndicator/SusAPCCarerSupportIndicator.cs
+++ b/OmopTransformer/SUS/APC/Observation/CarerSupportIndicator/SusAPCCarerSupportIndicator.cs
@@ -21,7 +21,7 @@ internal class SusAPCCarerSupportIndicator : OmopObservation<SusAPCCarerSupportI
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4224770, "Social support status")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.CDSActivityDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/GestationLengthLabourOnset/SusAPCGestationLengthLabourOnset.cs
+++ b/OmopTransformer/SUS/APC/Observation/GestationLengthLabourOnset/SusAPCGestationLengthLabourOnset.cs
@@ -21,7 +21,7 @@ internal class SusAPCGestationLengthLabourOnset : OmopObservation<SusAPCGestatio
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(40493181, "Length of gestation at time of procedure")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.observation_date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/NumberOfBabies/SusAPCNumberOfBabies.cs
+++ b/OmopTransformer/SUS/APC/Observation/NumberOfBabies/SusAPCNumberOfBabies.cs
@@ -21,7 +21,7 @@ internal class SusAPCNumberOfBabies : OmopObservation<SusAPCNumberOfBabiesRecord
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4209211, "Number of births at term")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.observation_date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/ReferralReceivedDateForInpatients/SusAPCReferralReceivedDateForInpatients.cs
+++ b/OmopTransformer/SUS/APC/Observation/ReferralReceivedDateForInpatients/SusAPCReferralReceivedDateForInpatients.cs
@@ -18,7 +18,7 @@ internal class SusAPCReferralReceivedDateForInpatients : OmopObservation<SusAPCR
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(40760321, "Date of Referral")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.StartDateHospitalProviderSpell))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/SourceOfReferralForInpatients/SusAPCSourceOfReferralForInpatients.cs
+++ b/OmopTransformer/SUS/APC/Observation/SourceOfReferralForInpatients/SusAPCSourceOfReferralForInpatients.cs
@@ -18,7 +18,7 @@ internal class SusAPCSourceOfReferralForInpatients : OmopObservation<SusAPCSourc
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.StartDateHospitalProviderSpell))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/Observation/TotalPreviousPregnancies/SusAPCTotalPreviousPregnancies.cs
+++ b/OmopTransformer/SUS/APC/Observation/TotalPreviousPregnancies/SusAPCTotalPreviousPregnancies.cs
@@ -21,7 +21,7 @@ internal class SusAPCTotalPreviousPregnancies : OmopObservation<SusAPCTotalPrevi
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [ConstantValue(4078008, "Number of previous pregnancies")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.observation_date))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/APC/ProcedureOccurrence/SusAPCProcedureOccurrence.cs
+++ b/OmopTransformer/SUS/APC/ProcedureOccurrence/SusAPCProcedureOccurrence.cs
@@ -10,7 +10,7 @@ internal class SusAPCProcedureOccurrence : OmopProcedureOccurrence<SusAPCProcedu
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.PrimaryProcedureDate))]
     public override DateTime? procedure_date { get; set; }

--- a/OmopTransformer/SUS/CCMDS/Measurements/BodyWeight/SusCCMDSMeasurementPersonWeight.cs
+++ b/OmopTransformer/SUS/CCMDS/Measurements/BodyWeight/SusCCMDSMeasurementPersonWeight.cs
@@ -31,7 +31,7 @@ internal class SusCCMDSMeasurementPersonWeight : OmopMeasurement<SusCCMDSMeasure
     public override int? unit_concept_id { get; set; }
 
     [ConstantValue(4099154, "Body Weight")]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     public override bool IsValid => base.IsValid && value_as_number != null;
 }

--- a/OmopTransformer/SUS/CCMDS/Measurements/GestationLengthAtDelivery/SusCCMDSMeasurementGestationLength.cs
+++ b/OmopTransformer/SUS/CCMDS/Measurements/GestationLengthAtDelivery/SusCCMDSMeasurementGestationLength.cs
@@ -28,7 +28,7 @@ internal class SusCCMDSMeasurementGestationLength : OmopMeasurement<SusCCMDSMeas
     public override int? unit_concept_id { get; set; }
 
     [ConstantValue(4260747, "Length of gestation at birth")]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     public override bool IsValid => base.IsValid && value_as_number != null;
 }

--- a/OmopTransformer/SUS/CCMDS/Observation/HighCostDrugs/SusCCMDSHighCostDrugs.cs
+++ b/OmopTransformer/SUS/CCMDS/Observation/HighCostDrugs/SusCCMDSHighCostDrugs.cs
@@ -13,7 +13,7 @@ internal class SusCCMDSHighCostDrugs : OmopObservation<SusCCMDSHighCostDrugsReco
     public override string? HospitalProviderSpellNumber { get; set; }
 
     [Transform(typeof(StandardConceptSelector), useOmopTypeAsSource: true, nameof(observation_source_concept_id))]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.ObservationDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/CCMDS/ProcedureOccurrence/SusCCMDSProcedureOccurrence.cs
+++ b/OmopTransformer/SUS/CCMDS/ProcedureOccurrence/SusCCMDSProcedureOccurrence.cs
@@ -10,7 +10,7 @@ internal class SusCCMDSProcedureOccurrence : OmopProcedureOccurrence<SusCCMDSPro
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.ProcedureOccurrenceStartDate))]
     public override DateTime? procedure_date { get; set; }

--- a/OmopTransformer/SUS/OP/ConditionOccurrence/SusOPConditionOccurrence.cs
+++ b/OmopTransformer/SUS/OP/ConditionOccurrence/SusOPConditionOccurrence.cs
@@ -13,7 +13,7 @@ internal class SusOPConditionOccurrence : OmopConditionOccurrence<SusOPCondition
     public override int? condition_source_concept_id { get; set; }
 
     [Transform(typeof(StandardConditionConceptSelector), useOmopTypeAsSource: true, nameof(condition_source_concept_id))]
-    public override int? condition_concept_id { get; set; }
+    public override int[]? condition_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.CDSActivityDate))]
     public override DateTime? condition_start_date { get; set; }

--- a/OmopTransformer/SUS/OP/Measurements/SusOPMeasurement.cs
+++ b/OmopTransformer/SUS/OP/Measurements/SusOPMeasurement.cs
@@ -25,7 +25,7 @@ internal class SusOPMeasurement : OmopMeasurement<SusOPMeasurementRecord>
     public override string? value_source_value { get; set; }
 
     [Transform(typeof(StandardMeasurementConceptSelector), useOmopTypeAsSource: true, nameof(measurement_source_concept_id))]
-    public override int? measurement_concept_id { get; set; }
+    public override int[]? measurement_concept_id { get; set; }
 
     public override bool IsValid => base.IsValid && value_source_value != null;
 }

--- a/OmopTransformer/SUS/OP/Observation/CarerSupportIndicator/SusOPCarerSupportIndicator.cs
+++ b/OmopTransformer/SUS/OP/Observation/CarerSupportIndicator/SusOPCarerSupportIndicator.cs
@@ -18,7 +18,7 @@ internal class SusOPCarerSupportIndicator : OmopObservation<SusOPCarerSupportInd
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(4224770, "Social support status")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.CDSActivityDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/OP/Observation/ReferralReceivedDateForOutpatients/SusOPReferralReceivedDateForOutpatients.cs
+++ b/OmopTransformer/SUS/OP/Observation/ReferralReceivedDateForOutpatients/SusOPReferralReceivedDateForOutpatients.cs
@@ -18,7 +18,7 @@ internal class SusOPReferralReceivedDateForOutpatients : OmopObservation<SusOPRe
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(40760321, "Date of Referral")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.AppointmentDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/OP/Observation/SourceOfReferralForOutpatients/SusOPSourceOfReferralForOutpatients.cs
+++ b/OmopTransformer/SUS/OP/Observation/SourceOfReferralForOutpatients/SusOPSourceOfReferralForOutpatients.cs
@@ -18,7 +18,7 @@ internal class SusOPSourceOfReferralForOutpatients : OmopObservation<SusOPSource
     public override string? RecordConnectionIdentifier { get; set; }
 
     [ConstantValue(4258129, "Referral by")]
-    public override int? observation_concept_id { get; set; }
+    public override int[]? observation_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.AppointmentDate))]
     public override DateTime? observation_date { get; set; }

--- a/OmopTransformer/SUS/OP/ProcedureOccurrence/SusOPProcedureOccurrence.cs
+++ b/OmopTransformer/SUS/OP/ProcedureOccurrence/SusOPProcedureOccurrence.cs
@@ -10,7 +10,7 @@ internal class SusOPProcedureOccurrence : OmopProcedureOccurrence<SusOPProcedure
     public override string? nhs_number { get; set; }
 
     [Transform(typeof(StandardProcedureConceptSelector), useOmopTypeAsSource: true, nameof(procedure_source_concept_id))]
-    public override int? procedure_concept_id { get; set; }
+    public override int[]? procedure_concept_id { get; set; }
 
     [Transform(typeof(DateConverter), nameof(Source.AppointmentDate))]
     public override DateTime? procedure_date { get; set; }

--- a/OmopTransformer/StandardConceptSelector.cs
+++ b/OmopTransformer/StandardConceptSelector.cs
@@ -11,6 +11,6 @@ internal class StandardConceptSelector(int? conceptId, ConceptResolver resolver)
         if (conceptId.HasValue == false)
             return null;
 
-        return resolver.GetConcept(conceptId.Value, null);
+        return resolver.GetConcepts(conceptId.Value, null);
     } 
 }

--- a/OmopTransformer/StandardConditionConceptSelector.cs
+++ b/OmopTransformer/StandardConditionConceptSelector.cs
@@ -11,6 +11,6 @@ internal class StandardConditionConceptSelector(int? conceptId, ConceptResolver 
         if (conceptId.HasValue == false)
             return null;
 
-        return resolver.GetConcept(conceptId.Value, "Condition");
+        return resolver.GetConcepts(conceptId.Value, "Condition");
     }
 }

--- a/OmopTransformer/StandardDeviceConceptSelector.cs
+++ b/OmopTransformer/StandardDeviceConceptSelector.cs
@@ -11,6 +11,6 @@ internal class StandardDeviceConceptSelector(int? conceptId, ConceptResolver res
         if (conceptId.HasValue == false)
             return null;
 
-        return resolver.GetConcept(conceptId.Value, "Device");
+        return resolver.GetConcepts(conceptId.Value, "Device");
     }
 }

--- a/OmopTransformer/StandardDrugConceptSelector.cs
+++ b/OmopTransformer/StandardDrugConceptSelector.cs
@@ -11,6 +11,6 @@ internal class StandardDrugConceptSelector(int? conceptId, ConceptResolver resol
         if (conceptId.HasValue == false)
             return null;
 
-        return resolver.GetConcept(conceptId.Value, "Drug");
+        return resolver.GetConcepts(conceptId.Value, "Drug");
     }
 }

--- a/OmopTransformer/StandardMeasurementConceptSelector.cs
+++ b/OmopTransformer/StandardMeasurementConceptSelector.cs
@@ -11,6 +11,6 @@ internal class StandardMeasurementConceptSelector(int? conceptId, ConceptResolve
         if (conceptId.HasValue == false)
             return null;
 
-        return resolver.GetConcept(conceptId.Value, "Measurement");
+        return resolver.GetConcepts(conceptId.Value, "Measurement");
     }
 }

--- a/OmopTransformer/StandardProcedureConceptSelector.cs
+++ b/OmopTransformer/StandardProcedureConceptSelector.cs
@@ -11,6 +11,6 @@ internal class StandardProcedureConceptSelector(int? conceptId, ConceptResolver 
         if (conceptId.HasValue == false)
             return null;
 
-        return resolver.GetConcept(conceptId.Value, "Procedure");
+        return resolver.GetConcepts(conceptId.Value, "Procedure");
     }
 }

--- a/OmopTransformer/Transformation/RecordTransformer.cs
+++ b/OmopTransformer/Transformation/RecordTransformer.cs
@@ -212,37 +212,37 @@ internal class RecordTransformer : IRecordTransformer
         if (property.PropertyType == value.GetType() || Nullable.GetUnderlyingType(property.PropertyType) == value.GetType())
         {
             property.SetValue(record, value);
+            return;
+        }
+
+        // If the target type is a collection, create an array of one item.
+        if (property.PropertyType.IsArray)
+        {
+            if (property.PropertyType.GetElementType() == typeof(int))
+            {
+                property.SetValue(record, new int[] { (int)value });
+                return;
+            }
         }
         else
         {
-            // If the target type is a collection, create an array of one item.
-            if (property.PropertyType.IsArray)
+            if (property.PropertyType == typeof(string))
             {
-                if (property.PropertyType.GetElementType() == typeof(int))
+                // Convert our int to a string and set the property.
+                if (value is int)
                 {
-                    property.SetValue(record, new int[] { (int)value });
+                    property.SetValue(record, value.ToString());
+                    return;
                 }
             }
-            else
-            {
-                if (property.PropertyType == typeof(string))
-                {
-                    // Convert our int to a string and set the property.
-                    if (value is int)
-                    {
-                        property.SetValue(record, value.ToString());
-                        return;
-                    }
-                }
 
-                if (property.PropertyType == typeof(int) || property.PropertyType == typeof(int?))
+            if (property.PropertyType == typeof(int) || property.PropertyType == typeof(int?))
+            {
+                // Convert our string to a int and set the property.
+                if (value is string s)
                 {
-                    // Convert our string to a int and set the property.
-                    if (value is string s)
-                    {
-                        property.SetValue(record, int.Parse(s));
-                        return;
-                    }
+                    property.SetValue(record, int.Parse(s));
+                    return;
                 }
             }
         }

--- a/OmopTransformer/Transformation/RecordTransformer.cs
+++ b/OmopTransformer/Transformation/RecordTransformer.cs
@@ -134,7 +134,8 @@ internal class RecordTransformer : IRecordTransformer
         
         if (lookup.Mappings.TryGetValue(argument, out var value))
         {
-            SetValue(record, property, value.Value);
+            if (value.Value != "")
+                SetValue(record, property, value.Value);
 
             _recordTransformLookupLogger.Hit(lookup);
         }

--- a/OmopTransformer/Transformation/RecordTransformer.cs
+++ b/OmopTransformer/Transformation/RecordTransformer.cs
@@ -221,8 +221,17 @@ internal class RecordTransformer : IRecordTransformer
         {
             if (property.PropertyType.GetElementType() == typeof(int))
             {
-                property.SetValue(record, new int[] { (int)value });
-                return;
+                if (value is int i)
+                {
+                    property.SetValue(record, new int[] { i });
+                    return;
+                }
+
+                if (value is string s)
+                {
+                    property.SetValue(record, new int[] { int.Parse(s) });
+                    return;
+                }
             }
         }
         else


### PR DESCRIPTION
Added support for mapping a non standard mapping to many standard mappings, rather than nominating a single standard concept. Used in situations such as multi ingredient drugs that need to be mapped to many standard drugs that represent each drug in the mixture.