### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/tvs-sde/oxford-omop-data-mapper/security/code-scanning/1](https://github.com/tvs-sde/oxford-omop-data-mapper/security/code-scanning/1)

Add an explicit `permissions` block to the workflow, scoped to the minimum needed privileges.  
Best fix here (without changing functionality): set workflow-level permissions to `contents: read`, since all jobs in this file are build/test and only require repository read access (including checkout). This should be added near the top level (after `on:` is a common placement), so it applies to all current/future jobs unless overridden.

File to change:
- `.github/workflows/dotnet.yml`
  - Insert:
    - `permissions:`
    - `  contents: read`
  - Place it before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
